### PR TITLE
Adds a `quiet` parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# duckspatial 0.2.0999 dev
+
+## MINOR CHANGES
+
+* All functions now have a parameter `quiet` that allows users to supress informational messages. Closed [#3](https://github.com/Cidree/duckspatial/issues/3)
+
 
 # duckspatial 0.2.0
 

--- a/R/binary_operations.R
+++ b/R/binary_operations.R
@@ -18,6 +18,7 @@
 #' to NULL if absent
 #' @param overwrite whether to overwrite the existing table if it exists. Ignored
 #' when name is NULL
+#' @template quiet
 #'
 #' @returns an sf object or TRUE (invisibly) for table creation
 #' @export
@@ -51,7 +52,8 @@ ddbs_intersection <- function(conn,
                               name = NULL,
                               crs = NULL,
                               crs_column = "crs_duckspatial",
-                              overwrite = FALSE) {
+                              overwrite = FALSE,
+                              quiet = FALSE) {
 
     ## 1. check conn
     dbConnCheck(conn)
@@ -76,7 +78,10 @@ ddbs_intersection <- function(conn,
         ## handle overwrite
         if (overwrite) {
             DBI::dbExecute(conn, glue::glue("DROP TABLE IF EXISTS {name_list$query_name};"))
-            cli::cli_alert_info("Table <{name_list$query_name}> dropped")
+
+            if (isFALSE(quiet)) {
+                cli::cli_alert_info("Table <{name_list$query_name}> dropped")
+            }
         }
 
         ## create query (no st_as_text)
@@ -95,7 +100,11 @@ ddbs_intersection <- function(conn,
         }
         ## execute intersection query
         DBI::dbExecute(conn, glue::glue("CREATE TABLE {name_list$query_name} AS {tmp.query}"))
-        cli::cli_alert_success("Query successful")
+
+        if (isFALSE(quiet)) {
+            cli::cli_alert_success("Query successful")
+        }
+
         return(invisible(TRUE))
     }
 
@@ -132,7 +141,10 @@ ddbs_intersection <- function(conn,
             sf::st_as_sf(wkt = x_geom, crs = crs)
     }
 
-    cli::cli_alert_success("Query successful")
+    if (isFALSE(quiet)) {
+        cli::cli_alert_success("Query successful")
+    }
+
     return(data_sf)
 }
 
@@ -160,6 +172,7 @@ ddbs_intersection <- function(conn,
 #' to NULL if absent
 #' @param overwrite whether to overwrite the existing table if it exists. Ignored
 #' when name is NULL
+#' @template quiet
 #'
 #' @returns an sf object or TRUE (invisibly) for table creation
 #' @export
@@ -193,7 +206,8 @@ ddbs_difference <- function(conn,
                             name = NULL,
                             crs = NULL,
                             crs_column = "crs_duckspatial",
-                            overwrite = FALSE) {
+                            overwrite = FALSE,
+                            quiet = FALSE) {
 
     ## 1. check conn
     dbConnCheck(conn)
@@ -218,7 +232,10 @@ ddbs_difference <- function(conn,
         ## handle overwrite
         if (overwrite) {
             DBI::dbExecute(conn, glue::glue("DROP TABLE IF EXISTS {name_list$query_name};"))
-            cli::cli_alert_info("Table <{name_list$query_name}> dropped")
+
+            if (isFALSE(quiet)) {
+                cli::cli_alert_info("Table <{name_list$query_name}> dropped")
+            }
         }
 
         ## create query (no st_as_text)
@@ -249,7 +266,10 @@ ddbs_difference <- function(conn,
           WHERE ST_IsEmpty({x_geom})
         "))
 
-        cli::cli_alert_success("Query successful")
+        if (isFALSE(quiet)) {
+            cli::cli_alert_success("Query successful")
+        }
+
         return(invisible(TRUE))
     }
 
@@ -293,6 +313,9 @@ ddbs_difference <- function(conn,
     ## remove empty features
     data_sf <- data_sf[!sf::st_is_empty(data_sf), ]
 
-    cli::cli_alert_success("Query successful")
+    if (isFALSE(quiet)) {
+        cli::cli_alert_success("Query successful")
+    }
+
     return(data_sf)
 }

--- a/R/db_extension.R
+++ b/R/db_extension.R
@@ -5,6 +5,7 @@
 #'
 #' @param conn a connection object to a DuckDB database
 #' @param upgrade if TRUE, it upgrades the DuckDB extension to the latest version
+#' @template quiet
 #'
 #' @returns TRUE (invisibly) for successful installation
 #' @export
@@ -22,7 +23,7 @@
 #'
 #' ## disconnect from db
 #' dbDisconnect(conn)
-ddbs_install <- function(conn, upgrade = FALSE) {
+ddbs_install <- function(conn, upgrade = FALSE, quiet = FALSE) {
 
     # 1. Get extensions list
     ext <- DBI::dbGetQuery(conn, "SELECT * FROM duckdb_extensions();")
@@ -36,13 +37,21 @@ ddbs_install <- function(conn, upgrade = FALSE) {
     ## 2.3. Check if it's installed
     spatial_ext <- ext[ext$extension_name == "spatial", ]
     if (spatial_ext$installed & !upgrade) {
-        cli::cli_alert_info("spatial extension version <{spatial_ext$extension_version}> is already installed in this database")
+
+        if (isFALSE(quiet)) {
+            cli::cli_alert_info("spatial extension version <{spatial_ext$extension_version}> is already installed in this database")
+        }
+
         return(invisible(TRUE))
     }
 
     # 3. Install extension
     suppressMessages(DBI::dbExecute(conn, "INSTALL spatial;"))
-    cli::cli_alert_success("Spatial extension installed")
+
+    if (isFALSE(quiet)) {
+        cli::cli_alert_success("Spatial extension installed")
+    }
+
     return(invisible(TRUE))
 
 
@@ -54,6 +63,7 @@ ddbs_install <- function(conn, upgrade = FALSE) {
 #' Checks if a spatial extension is installed, and loads it in a DuckDB database
 #'
 #' @param conn a connection object to a DuckDB database
+#' @template quiet
 #'
 #' @returns TRUE (invisibly) for successful installation
 #' @export
@@ -72,7 +82,7 @@ ddbs_install <- function(conn, upgrade = FALSE) {
 #'
 #' ## disconnect from db
 #' dbDisconnect(conn)
-ddbs_load <- function(conn) {
+ddbs_load <- function(conn, quiet = FALSE) {
 
     # 1. Get extensions list
     ext <- DBI::dbGetQuery(conn, "SELECT * FROM duckdb_extensions();")
@@ -87,6 +97,9 @@ ddbs_load <- function(conn) {
 
     # 3. Load spatial extension
     suppressMessages(DBI::dbExecute(conn, "LOAD spatial;"))
-    cli::cli_alert_success("Spatial extension loaded")
+
+    if (isFALSE(quiet)) {
+        cli::cli_alert_success("Spatial extension loaded")
+    }
 
 }

--- a/R/db_read.R
+++ b/R/db_read.R
@@ -14,6 +14,7 @@
 #' to NULL if absent
 #' @param clauses character, additional SQL code to modify the query from the
 #' table (e.g. "WHERE ...", "ORDER BY...")
+#' @template quiet
 #'
 #' @returns an sf object
 #' @export
@@ -49,7 +50,12 @@
 #'
 #' ## disconnect from db
 #' dbDisconnect(conn)
-ddbs_read_vector <- function(conn, name, crs = NULL, crs_column = "crs_duckspatial", clauses = NULL) {
+ddbs_read_vector <- function(conn,
+                             name,
+                             crs = NULL,
+                             crs_column = "crs_duckspatial",
+                             clauses = NULL,
+                             quiet = FALSE) {
 
   # 1. Checks
   ## Check if connection is correct
@@ -89,7 +95,12 @@ ddbs_read_vector <- function(conn, name, crs = NULL, crs_column = "crs_duckspati
       data_sf <- data_tbl |>
           sf::st_as_sf(wkt = geom_name, crs = crs)
   }
-  cli::cli_alert_success("Table {name} successfully imported.")
+
+
+  if (isFALSE(quiet)) {
+      cli::cli_alert_success("Table {name} successfully imported.")
+  }
+
   return(data_sf)
 
 }

--- a/R/db_utils.R
+++ b/R/db_utils.R
@@ -1,9 +1,8 @@
-
-
 #' Check and create schema
 #'
 #' @param conn a connection object to a DuckDB database
 #' @param name a character string with the name of the schema to be created
+#' @template quiet
 #'
 #' @returns TRUE (invisibly) for successful schema creation
 #' @export
@@ -25,7 +24,7 @@
 #' ## disconnect from db
 #' dbDisconnect(conn)
 #'
-ddbs_create_schema <- function(conn, name) {
+ddbs_create_schema <- function(conn, name, quiet = FALSE) {
 
     # 1. Checks
     ## Check if connection is correct
@@ -43,7 +42,10 @@ ddbs_create_schema <- function(conn, name) {
             conn,
             glue::glue("CREATE SCHEMA {name};")
         )
-        cli::cli_alert_success("Schema {name} created")
+
+        if (isFALSE(quiet)) {
+            cli::cli_alert_success("Schema {name} created")
+        }
     }
     return(invisible(TRUE))
 
@@ -142,13 +144,18 @@ ddbs_list_tables <- function(conn) {
 #' doesn't have crs_column, and you know the crs
 #' @param crs_column a character string of length one specifying the column
 #' storing the CRS (created automatically by \code{\link{ddbs_write_vector}})
+#' @template quiet
 #'
 #' @returns `sf` object
 #' @export
 #'
 #' @examplesIf interactive()
 #' ## TODO
-ddbs_glimpse <- function(conn, name, crs = NULL, crs_column = "crs_duckspatial") {
+ddbs_glimpse <- function(conn,
+                         name,
+                         crs = NULL,
+                         crs_column = "crs_duckspatial",
+                         quiet = FALSE) {
 
     ## 1. check conn
     dbConnCheck(conn)
@@ -184,7 +191,11 @@ ddbs_glimpse <- function(conn, name, crs = NULL, crs_column = "crs_duckspatial")
         data_sf <- data_tbl |>
             sf::st_as_sf(wkt = geom_name, crs = crs)
     }
-    cli::cli_alert_success("Showing first 10 rows of the data")
+
+    if (isFALSE(quiet)) {
+        cli::cli_alert_success("Showing first 10 rows of the data")
+    }
+
     return(data_sf)
 
 }

--- a/R/db_write.R
+++ b/R/db_write.R
@@ -1,4 +1,3 @@
-
 #' Write an SF Object to a DuckDB Database
 #'
 #' This function writes a Simple Features (SF) object into a DuckDB database as a new table.
@@ -9,6 +8,7 @@
 #' @param name a character string of length one specifying the name of the table,
 #' or a character string of length two specifying the schema and table names.
 #' @param overwrite whether to overwrite the existing table if it exists
+#' @template quiet
 #'
 #' @returns TRUE (invisibly) for successful import
 #' @export
@@ -44,7 +44,7 @@
 #'
 #' ## disconnect from db
 #' dbDisconnect(conn)
-ddbs_write_vector <- function(conn, data, name, overwrite = FALSE) {
+ddbs_write_vector <- function(conn, data, name, overwrite = FALSE, quiet = FALSE) {
 
     # 1. Checks
     ## Check if connection is correct
@@ -147,7 +147,10 @@ ddbs_write_vector <- function(conn, data, name, overwrite = FALSE) {
 
 
     # 6. User feedback
-    cli::cli_alert_success("Table {name_list$query_name} successfully imported")
+    if (isFALSE(quiet)) {
+        cli::cli_alert_success("Table {name_list$query_name} successfully imported")
+        }
+
     return(invisible(TRUE))
 
 }

--- a/R/st_filter.R
+++ b/R/st_filter.R
@@ -20,6 +20,7 @@
 #' to NULL if absent
 #' @param overwrite whether to overwrite the existing table if it exists. Ignored
 #' when name is NULL
+#' @template quiet
 #'
 #' @returns an sf object or TRUE (invisibly) for table creation
 #' @export
@@ -54,7 +55,8 @@ ddbs_filter <- function(conn,
                         predicate = "intersection",
                         crs = NULL,
                         crs_column = "crs_duckspatial",
-                        overwrite = FALSE) {
+                        overwrite = FALSE,
+                        quiet = FALSE) {
 
     ## 1. select predicate
     sel_pred <- switch(predicate,
@@ -97,7 +99,10 @@ ddbs_filter <- function(conn,
         ## handle overwrite
         if (overwrite) {
             DBI::dbExecute(conn, glue::glue("DROP TABLE IF EXISTS {name_list$query_name};"))
-            cli::cli_alert_info("Table <{name_list$query_name}> dropped")
+
+            if (isFALSE(quiet)) {
+                cli::cli_alert_info("Table <{name_list$query_name}> dropped")
+            }
         }
 
         tmp.query <- glue::glue("
@@ -108,7 +113,11 @@ ddbs_filter <- function(conn,
         ")
         ## execute filter query
         DBI::dbExecute(conn, tmp.query)
-        cli::cli_alert_success("Query successful")
+
+        if (isFALSE(quiet)) {
+            cli::cli_alert_success("Query successful")
+        }
+
         return(invisible(TRUE))
     }
 
@@ -136,7 +145,11 @@ ddbs_filter <- function(conn,
         data_sf <- data_tbl |>
             sf::st_as_sf(wkt = x_geom, crs = crs)
     }
-    cli::cli_alert_success("Query successful")
+
+    if (isFALSE(quiet)) {
+        cli::cli_alert_success("Query successful")
+    }
+
     return(data_sf)
 }
 

--- a/R/unary_operations.R
+++ b/R/unary_operations.R
@@ -20,6 +20,7 @@
 #' to NULL if absent
 #' @param overwrite whether to overwrite the existing table if it exists. Ignored
 #' when \code{name} is NULL
+#' @template quiet
 #'
 #' @returns an \code{sf} object or \code{TRUE} (invisibly) for table creation
 #' @export
@@ -51,7 +52,8 @@ ddbs_buffer <- function(conn,
                         name = NULL,
                         crs = NULL,
                         crs_column = "crs_duckspatial",
-                        overwrite = FALSE) {
+                        overwrite = FALSE,
+                        quiet = FALSE) {
 
     ## 1. check conn
     dbConnCheck(conn)
@@ -73,7 +75,10 @@ ddbs_buffer <- function(conn,
         ## handle overwrite
         if (overwrite) {
             DBI::dbExecute(conn, glue::glue("DROP TABLE IF EXISTS {name_list$query_name};"))
-            cli::cli_alert_info("Table <{name_list$query_name}> dropped")
+
+            if (isFALSE(quiet)) {
+                cli::cli_alert_info("Table <{name_list$query_name}> dropped")
+            }
         }
 
         ## create query (no st_as_text)
@@ -88,7 +93,11 @@ ddbs_buffer <- function(conn,
         }
         ## execute intersection query
         DBI::dbExecute(conn, glue::glue("CREATE TABLE {name_list$query_name} AS {tmp.query}"))
-        cli::cli_alert_success("Query successful")
+
+        if (isFALSE(quiet)) {
+            cli::cli_alert_success("Query successful")
+        }
+
         return(invisible(TRUE))
     }
 
@@ -121,7 +130,10 @@ ddbs_buffer <- function(conn,
             sf::st_as_sf(wkt = x_geom, crs = crs)
     }
 
-    cli::cli_alert_success("Query successful")
+    if (isFALSE(quiet)) {
+        cli::cli_alert_success("Query successful")
+    }
+
     return(data_sf)
 }
 

--- a/man/ddbs_buffer.Rd
+++ b/man/ddbs_buffer.Rd
@@ -11,7 +11,8 @@ ddbs_buffer(
   name = NULL,
   crs = NULL,
   crs_column = "crs_duckspatial",
-  overwrite = FALSE
+  overwrite = FALSE,
+  quiet = FALSE
 )
 }
 \arguments{
@@ -35,6 +36,9 @@ to NULL if absent}
 
 \item{overwrite}{whether to overwrite the existing table if it exists. Ignored
 when \code{name} is NULL}
+
+\item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.
+Defaults to \code{FALSE}.}
 }
 \value{
 an \code{sf} object or \code{TRUE} (invisibly) for table creation

--- a/man/ddbs_create_schema.Rd
+++ b/man/ddbs_create_schema.Rd
@@ -4,12 +4,15 @@
 \alias{ddbs_create_schema}
 \title{Check and create schema}
 \usage{
-ddbs_create_schema(conn, name)
+ddbs_create_schema(conn, name, quiet = FALSE)
 }
 \arguments{
 \item{conn}{a connection object to a DuckDB database}
 
 \item{name}{a character string with the name of the schema to be created}
+
+\item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.
+Defaults to \code{FALSE}.}
 }
 \value{
 TRUE (invisibly) for successful schema creation

--- a/man/ddbs_difference.Rd
+++ b/man/ddbs_difference.Rd
@@ -11,7 +11,8 @@ ddbs_difference(
   name = NULL,
   crs = NULL,
   crs_column = "crs_duckspatial",
-  overwrite = FALSE
+  overwrite = FALSE,
+  quiet = FALSE
 )
 }
 \arguments{
@@ -35,6 +36,9 @@ to NULL if absent}
 
 \item{overwrite}{whether to overwrite the existing table if it exists. Ignored
 when name is NULL}
+
+\item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.
+Defaults to \code{FALSE}.}
 }
 \value{
 an sf object or TRUE (invisibly) for table creation

--- a/man/ddbs_filter.Rd
+++ b/man/ddbs_filter.Rd
@@ -12,7 +12,8 @@ ddbs_filter(
   predicate = "intersection",
   crs = NULL,
   crs_column = "crs_duckspatial",
-  overwrite = FALSE
+  overwrite = FALSE,
+  quiet = FALSE
 )
 }
 \arguments{
@@ -38,6 +39,9 @@ to NULL if absent}
 
 \item{overwrite}{whether to overwrite the existing table if it exists. Ignored
 when name is NULL}
+
+\item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.
+Defaults to \code{FALSE}.}
 }
 \value{
 an sf object or TRUE (invisibly) for table creation

--- a/man/ddbs_glimpse.Rd
+++ b/man/ddbs_glimpse.Rd
@@ -4,7 +4,13 @@
 \alias{ddbs_glimpse}
 \title{Check first rows of the data}
 \usage{
-ddbs_glimpse(conn, name, crs = NULL, crs_column = "crs_duckspatial")
+ddbs_glimpse(
+  conn,
+  name,
+  crs = NULL,
+  crs_column = "crs_duckspatial",
+  quiet = FALSE
+)
 }
 \arguments{
 \item{conn}{a connection object to a DuckDB database}
@@ -17,6 +23,9 @@ doesn't have crs_column, and you know the crs}
 
 \item{crs_column}{a character string of length one specifying the column
 storing the CRS (created automatically by \code{\link{ddbs_write_vector}})}
+
+\item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.
+Defaults to \code{FALSE}.}
 }
 \value{
 \code{sf} object

--- a/man/ddbs_install.Rd
+++ b/man/ddbs_install.Rd
@@ -4,12 +4,15 @@
 \alias{ddbs_install}
 \title{Checks and installs the Spatial extension}
 \usage{
-ddbs_install(conn, upgrade = FALSE)
+ddbs_install(conn, upgrade = FALSE, quiet = FALSE)
 }
 \arguments{
 \item{conn}{a connection object to a DuckDB database}
 
 \item{upgrade}{if TRUE, it upgrades the DuckDB extension to the latest version}
+
+\item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.
+Defaults to \code{FALSE}.}
 }
 \value{
 TRUE (invisibly) for successful installation

--- a/man/ddbs_intersection.Rd
+++ b/man/ddbs_intersection.Rd
@@ -11,7 +11,8 @@ ddbs_intersection(
   name = NULL,
   crs = NULL,
   crs_column = "crs_duckspatial",
-  overwrite = FALSE
+  overwrite = FALSE,
+  quiet = FALSE
 )
 }
 \arguments{
@@ -35,6 +36,9 @@ to NULL if absent}
 
 \item{overwrite}{whether to overwrite the existing table if it exists. Ignored
 when name is NULL}
+
+\item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.
+Defaults to \code{FALSE}.}
 }
 \value{
 an sf object or TRUE (invisibly) for table creation

--- a/man/ddbs_load.Rd
+++ b/man/ddbs_load.Rd
@@ -4,10 +4,13 @@
 \alias{ddbs_load}
 \title{Loads the Spatial extension}
 \usage{
-ddbs_load(conn)
+ddbs_load(conn, quiet = FALSE)
 }
 \arguments{
 \item{conn}{a connection object to a DuckDB database}
+
+\item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.
+Defaults to \code{FALSE}.}
 }
 \value{
 TRUE (invisibly) for successful installation

--- a/man/ddbs_read_vector.Rd
+++ b/man/ddbs_read_vector.Rd
@@ -9,7 +9,8 @@ ddbs_read_vector(
   name,
   crs = NULL,
   crs_column = "crs_duckspatial",
-  clauses = NULL
+  clauses = NULL,
+  quiet = FALSE
 )
 }
 \arguments{
@@ -27,6 +28,9 @@ to NULL if absent}
 
 \item{clauses}{character, additional SQL code to modify the query from the
 table (e.g. "WHERE ...", "ORDER BY...")}
+
+\item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.
+Defaults to \code{FALSE}.}
 }
 \value{
 an sf object

--- a/man/ddbs_write_vector.Rd
+++ b/man/ddbs_write_vector.Rd
@@ -4,7 +4,7 @@
 \alias{ddbs_write_vector}
 \title{Write an SF Object to a DuckDB Database}
 \usage{
-ddbs_write_vector(conn, data, name, overwrite = FALSE)
+ddbs_write_vector(conn, data, name, overwrite = FALSE, quiet = FALSE)
 }
 \arguments{
 \item{conn}{a connection object to a DuckDB database}
@@ -15,6 +15,9 @@ ddbs_write_vector(conn, data, name, overwrite = FALSE)
 or a character string of length two specifying the schema and table names.}
 
 \item{overwrite}{whether to overwrite the existing table if it exists}
+
+\item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.
+Defaults to \code{FALSE}.}
 }
 \value{
 TRUE (invisibly) for successful import

--- a/man/roxygen/templates/quiet.R
+++ b/man/roxygen/templates/quiet.R
@@ -1,0 +1,2 @@
+#' @param quiet A logical value. If `TRUE`, suppresses any informational messages.
+#'              Defaults to `FALSE`.


### PR DESCRIPTION
This PR implements a `quiet` parameter to all functions following the same format used in the {silviculture} package. 

```
── R CMD check results ─────────────────────────────────────────── duckspatial 0.2.0 ────
Duration: 18.9s

0 errors ✔ | 0 warnings ✔ | 0 notes ✔

```