### PR TITLE
feat: enhance CRS auto-detection in ddbs_crs for tbl_duckdb_connectio…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # duckspatial (development version)
 
+## ENHANCEMENTS
+
+* `ddbs_create_conn()` and `ddbs_write_dataset()` now create persistent DuckDB files with DuckDB `v1.5.0` storage by default so CRS metadata can persist in native `GEOMETRY` columns, with opt-in legacy comment metadata via `storage_version = "legacy"` for files that must be readable by DuckDB versions older than 1.5.0.
+
+* `ddbs_create_conn()`: stricter validation of `dbdir` parameter. Now only accepts `"memory"`, `"tempdir"`, or file paths with `.duckdb`, `.db`, or `.ddb` extensions.
+
+* `ddbs_stop_conn()`: now explicitly shuts down the DuckDB driver and forces a checkpoint (necessary to release the file lock on Windows).
+
+
+# duckspatial 1.1.0
+
 ## NEW FEATURES
 
 * Implementation of `duckspatial` macros: this allows to use some `duckspatial` functions within `dplyr` verbs (e.g. `data |> mutate(area = ddbs_area(geometry))`) (#92).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## ENHANCEMENTS
 
-* `ddbs_create_conn()` and `ddbs_write_dataset()` gain a `duckdb_storage_version` argument to control DuckDB storage compatibility. They now default to DuckDB `v1.5.0` storage (**Native Spatial Storage**) so that CRS metadata can persist in native `GEOMETRY` columns. Users can specify older versions (e.g., `v1.0.0` for **Legacy Compatibility**) when the output must be readable by older DuckDB clients.
+* `ddbs_create_conn()` and `ddbs_write_dataset()` gain a `duckdb_storage_version` argument to control DuckDB storage compatibility. They now default to DuckDB `v1.5.0` storage (**Native Spatial Storage**) so that CRS metadata can persist in native `GEOMETRY` columns. Users can specify older versions (e.g., `v1.0.0` for **Legacy Compatibility**) when the output must be readable by older DuckDB clients. For more details on DuckDB storage versions, see <https://duckdb.org/docs/internals/storage>.
 
 * `ddbs_create_conn()`: stricter validation of `dbdir` parameter. Now only accepts `"memory"`, `"tempdir"`, or file paths with `.duckdb`, `.db`, or `.ddb` extensions.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## ENHANCEMENTS
 
-* `ddbs_create_conn()` and `ddbs_write_dataset()` now create persistent DuckDB files with DuckDB `v1.5.0` storage by default so CRS metadata can persist in native `GEOMETRY` columns, with opt-in legacy comment metadata via `storage_version = "legacy"` for files that must be readable by DuckDB versions older than 1.5.0.
+* `ddbs_create_conn()` and `ddbs_write_dataset()` gain a `duckdb_storage_version` argument to control DuckDB storage compatibility. They now default to DuckDB `v1.5.0` storage (**Native Spatial Storage**) so that CRS metadata can persist in native `GEOMETRY` columns. Users can specify older versions (e.g., `v1.0.0` for **Legacy Compatibility**) when the output must be readable by older DuckDB clients.
 
 * `ddbs_create_conn()`: stricter validation of `dbdir` parameter. Now only accepts `"memory"`, `"tempdir"`, or file paths with `.duckdb`, `.db`, or `.ddb` extensions.
 

--- a/R/crs_persistence.R
+++ b/R/crs_persistence.R
@@ -1,9 +1,49 @@
 duckspatial_storage_default <- function() {
-  "v1.5.0"
+  getOption("duckspatial.duckdb_storage_version", "v1.5.0")
 }
 
 duckspatial_storage_versions <- function() {
-  c(duckspatial_storage_default(), "legacy")
+  c(duckspatial_storage_default(), "v1.4.0", "v1.3.0", "v1.2.0", "v1.0.0", "latest")
+}
+
+match_duckdb_storage_version <- function(x) {
+  if (!is.character(x) || length(x) != 1) {
+    cli::cli_abort("{.arg duckdb_storage_version} must be a single string.")
+  }
+
+  choices <- duckspatial_storage_versions()
+
+  # 1. Exact match in curated list (e.g., 'latest', 'v1.5.0', 'v1.0.0')
+  if (x %in% choices) {
+    return(x)
+  }
+
+  # 2. Pass-through for strings that look like DuckDB version tags (vX.Y.Z)
+  # This automatically supports future DuckDB releases without package updates.
+  # If the version is unknown to the DuckDB binary, it will throw a descriptive
+  # error during connection.
+  if (grepl("^v[0-9]+", x)) {
+    return(x)
+  }
+
+  # 3. Fallback to standard match.arg for suggestions/error reporting
+  match.arg(x, choices)
+}
+
+is_storage_v15_or_newer <- function(tag) {
+  if (is.null(tag) || is.na(tag) || !nzchar(tag)) {
+    return(FALSE)
+  }
+
+  # DuckDB tags can be "v1.5.0+", "v1.0.0 - v1.1.3", etc.
+  # We extract the first semantic version string found.
+  version_match <- regexpr("[0-9]+\\.[0-9]+\\.[0-9]+", tag)
+  if (version_match == -1) {
+    return(FALSE)
+  }
+
+  v_str <- regmatches(tag, version_match)
+  utils::compareVersion(v_str, "1.5.0") >= 0
 }
 
 ddbs_assert_duckdb_crs_support <- function() {
@@ -337,11 +377,12 @@ ddbs_duckdb_storage_tag <- function(conn) {
 
 ddbs_open_persistent <- function(
   dbdir,
-  storage_version = duckspatial_storage_default(),
+  duckdb_storage_version = duckspatial_storage_default(),
   read_only = FALSE,
   ...
 ) {
-  storage_version <- match.arg(storage_version, duckspatial_storage_versions())
+  duckdb_storage_version <- match_duckdb_storage_version(duckdb_storage_version)
+
   if (dbdir %in% c(":memory:", "memory")) {
     conn <- DBI::dbConnect(
       duckdb::duckdb(dbdir = ":memory:"),
@@ -354,8 +395,8 @@ ddbs_open_persistent <- function(
 
   is_new <- !file.exists(dbdir)
   config <- list()
-  if (is_new && !identical(storage_version, "legacy")) {
-    config$storage_compatibility_version <- storage_version
+  if (is_new && !identical(duckdb_storage_version, "v1.0.0")) {
+    config$storage_compatibility_version <- duckdb_storage_version
   }
 
   conn <- DBI::dbConnect(
@@ -365,22 +406,34 @@ ddbs_open_persistent <- function(
   )
 
   actual <- ddbs_duckdb_storage_tag(conn)
-  requested <- if (identical(storage_version, "legacy")) {
+  requested <- if (duckdb_storage_version %in% c("v1.0.0", "latest")) {
     NA_character_
   } else {
-    paste0(storage_version, "+")
+    paste0(duckdb_storage_version, "+")
   }
-  legacy_mode <- identical(storage_version, "legacy") ||
-    (!is.na(requested) && !identical(actual, requested))
+
+  # Fallback to legacy (comment) mode if storage is older than v1.5.0
+  legacy_mode <- !is_storage_v15_or_newer(actual)
 
   if (
-    !identical(storage_version, "legacy") &&
-      isTRUE(legacy_mode) &&
+    !legacy_mode &&
+      !is.na(requested) &&
+      !identical(actual, requested) &&
       !isTRUE(read_only)
   ) {
+    # If they requested a specific modern version but got a different modern version,
+    # we still use native spatial storage but warn.
     cli::cli_warn(
       c(
-        "Requested DuckDB storage {.val {storage_version}} but file storage is {.val {actual}}.",
+        "Requested DuckDB storage {.val {duckdb_storage_version}} but file storage is {.val {actual}}.",
+        "i" = "Native CRS persistence will be used."
+      ),
+      class = "duckspatial_storage_mismatch"
+    )
+  } else if (legacy_mode && !identical(duckdb_storage_version, "v1.0.0") && !isTRUE(read_only)) {
+    cli::cli_warn(
+      c(
+        "Requested DuckDB storage {.val {duckdb_storage_version}} but file storage is {.val {actual}} (Legacy).",
         "i" = "CRS persistence will use duckspatial-managed column-comment metadata for this compatibility connection."
       ),
       class = "duckspatial_storage_mismatch"
@@ -392,7 +445,7 @@ ddbs_open_persistent <- function(
   attr(conn, "duckspatial_storage_mode") <- if (legacy_mode) {
     "legacy"
   } else {
-    storage_version
+    duckdb_storage_version
   }
   conn
 }

--- a/R/crs_persistence.R
+++ b/R/crs_persistence.R
@@ -1,0 +1,398 @@
+duckspatial_storage_default <- function() {
+  "v1.5.0"
+}
+
+duckspatial_storage_versions <- function() {
+  c(duckspatial_storage_default(), "legacy")
+}
+
+ddbs_assert_duckdb_crs_support <- function() {
+  if (utils::packageVersion("duckdb") < "1.5.0") {
+    cli::cli_abort(c(
+      "duckspatial requires duckdb >= 1.5.0 to open files written by recent duckspatial versions.",
+      "i" = "Installed: {utils::packageVersion('duckdb')}. Upgrade: install.packages('duckdb')."
+    ))
+  }
+
+  invisible(TRUE)
+}
+
+ddbs_storage_is_legacy <- function(conn) {
+  identical(attr(conn, "duckspatial_storage_mode"), "legacy")
+}
+
+ddbs_input_crs_for_write <- function(data, conn = NULL) {
+  tryCatch(
+    {
+      if (inherits(data, "sf")) {
+        return(sf::st_crs(data))
+      }
+      if (
+        inherits(data, c("duckspatial_df", "tbl_duckdb_connection", "tbl_lazy"))
+      ) {
+        return(ddbs_crs(data))
+      }
+      if (
+        is.character(data) &&
+          length(data) == 1 &&
+          file.exists(data) &&
+          !has_duckdb_file_extension(data) &&
+          !is.null(conn)
+      ) {
+        return(get_file_crs(data, conn))
+      }
+      NULL
+    },
+    error = function(e) NULL
+  )
+}
+
+ddbs_write_legacy_crs_comment_if_needed <- function(
+  conn,
+  table,
+  geom_col = NULL,
+  crs = NULL
+) {
+  if (!ddbs_storage_is_legacy(conn)) {
+    return(invisible(FALSE))
+  }
+
+  if (is.null(crs) || is.na(sf::st_crs(crs))) {
+    return(invisible(FALSE))
+  }
+
+  geom_col <- geom_col %||%
+    tryCatch(get_geom_name(conn, table), error = function(e) NULL)
+  if (is.null(geom_col) || is.na(geom_col)) {
+    return(invisible(FALSE))
+  }
+
+  write_crs_comment(conn, table, geom_col, crs)
+}
+
+ddbs_quote_table <- function(conn, table) {
+  if (inherits(table, "SQL")) {
+    return(as.character(table))
+  }
+
+  if (length(table) == 2) {
+    return(as.character(DBI::dbQuoteIdentifier(
+      conn,
+      DBI::Id(schema = table[[1]], table = table[[2]])
+    )))
+  }
+
+  table <- as.character(table)
+  if (length(table) != 1) {
+    cli::cli_abort("{.arg table} must identify one table.")
+  }
+
+  parts <- strsplit(table, ".", fixed = TRUE)[[1]]
+  if (length(parts) == 2) {
+    return(as.character(DBI::dbQuoteIdentifier(
+      conn,
+      DBI::Id(schema = parts[[1]], table = parts[[2]])
+    )))
+  }
+
+  as.character(DBI::dbQuoteIdentifier(conn, table))
+}
+
+crs_to_duckdb_literal <- function(x) {
+  if (is.null(x)) {
+    return(list(literal = NA_character_, kind = "none"))
+  }
+
+  crs <- sf::st_crs(x)
+  if (is.na(crs)) {
+    return(list(literal = NA_character_, kind = "none"))
+  }
+
+  parsed <- sf::st_crs(crs, parameters = TRUE)
+  srid <- parsed$srid
+  if (!is.null(srid) && length(srid) > 0 && !is.na(srid)) {
+    return(list(literal = as.character(srid), kind = "authority"))
+  }
+
+  wkt <- crs$wkt
+  if (is.null(wkt) || length(wkt) == 0 || is.na(wkt) || !nzchar(wkt)) {
+    return(list(literal = NA_character_, kind = "none"))
+  }
+
+  list(literal = wkt, kind = "wkt")
+}
+
+ddbs_quote_sql_string <- function(conn, x) {
+  if (!is.null(conn)) {
+    return(as.character(DBI::dbQuoteString(conn, x)))
+  }
+
+  paste0("'", gsub("'", "''", x, fixed = TRUE), "'")
+}
+
+duckdb_geometry_type <- function(conn, x) {
+  lit <- crs_to_duckdb_literal(x)
+  if (identical(lit$kind, "none")) {
+    return("GEOMETRY")
+  }
+
+  paste0("GEOMETRY(", ddbs_quote_sql_string(conn, lit$literal), ")")
+}
+
+read_native_crs <- function(conn, table, geom_col) {
+  q_geom <- as.character(DBI::dbQuoteIdentifier(conn, geom_col))
+  q_table <- ddbs_quote_table(conn, table)
+  query <- paste0(
+    "SELECT ST_CRS(",
+    q_geom,
+    ") AS crs ",
+    "FROM ",
+    q_table,
+    " ",
+    "WHERE ",
+    q_geom,
+    " IS NOT NULL ",
+    "LIMIT 1"
+  )
+
+  res <- tryCatch(DBI::dbGetQuery(conn, query), error = function(e) NULL)
+  if (
+    is.null(res) ||
+      nrow(res) == 0 ||
+      is.na(res$crs[[1]]) ||
+      identical(res$crs[[1]], "")
+  ) {
+    return(sf::st_crs(NA))
+  }
+
+  sf::st_crs(res$crs[[1]])
+}
+
+make_crs_comment <- function(crs, geom_col, existing_payload = NULL) {
+  parsed <- sf::st_crs(crs)
+  payload <- list(
+    duckspatial = list(
+      version = 1L,
+      geometry_column = geom_col,
+      crs = list(
+        input = as.character(parsed$input),
+        authority = if (!is.null(parsed$authority)) parsed$authority else NULL,
+        srid = if (!is.na(parsed$epsg)) as.integer(parsed$epsg) else NULL,
+        wkt2_2019 = parsed$wkt
+      )
+    )
+  )
+
+  if (is.list(existing_payload) && !is.null(existing_payload$user_comment)) {
+    payload$duckspatial$user_comment <- existing_payload$user_comment
+  }
+
+  jsonlite::toJSON(payload, auto_unbox = TRUE, null = "null", na = "null")
+}
+
+parse_crs_comment <- function(comment_text) {
+  if (is.null(comment_text) || is.na(comment_text) || !nzchar(comment_text)) {
+    return(NULL)
+  }
+
+  obj <- tryCatch(
+    jsonlite::fromJSON(comment_text, simplifyVector = FALSE),
+    error = function(e) NULL
+  )
+  if (is.null(obj) || is.null(obj$duckspatial)) {
+    return(NULL)
+  }
+
+  obj$duckspatial
+}
+
+get_column_comment <- function(conn, table, geom_col) {
+  name_list <- get_query_name(table)
+  query <- paste0(
+    "SELECT comment FROM duckdb_columns() ",
+    "WHERE schema_name = ",
+    DBI::dbQuoteString(conn, name_list$schema_name),
+    " AND table_name = ",
+    DBI::dbQuoteString(conn, name_list$table_name),
+    " AND column_name = ",
+    DBI::dbQuoteString(conn, geom_col),
+    " LIMIT 1"
+  )
+  res <- DBI::dbGetQuery(conn, query)
+  if (nrow(res) == 0) {
+    return(NA_character_)
+  }
+
+  res$comment[[1]]
+}
+
+write_crs_comment <- function(conn, table, geom_col, crs) {
+  parsed <- sf::st_crs(crs)
+  if (is.na(parsed)) {
+    return(invisible(FALSE))
+  }
+
+  cur <- get_column_comment(conn, table, geom_col)
+  parsed_cur <- parse_crs_comment(cur)
+  existing <- NULL
+  if (is.null(parsed_cur) && !is.null(cur) && !is.na(cur) && nzchar(cur)) {
+    existing <- list(user_comment = cur)
+  }
+
+  payload <- make_crs_comment(parsed, geom_col, existing_payload = existing)
+  sql <- sprintf(
+    "COMMENT ON COLUMN %s.%s IS %s",
+    ddbs_quote_table(conn, table),
+    DBI::dbQuoteIdentifier(conn, geom_col),
+    DBI::dbQuoteString(conn, payload)
+  )
+  DBI::dbExecute(conn, sql)
+  invisible(TRUE)
+}
+
+crs_from_comment_payload <- function(payload) {
+  if (is.null(payload) || is.null(payload$crs)) {
+    return(sf::st_crs(NA))
+  }
+
+  pref <- NULL
+  if (!is.null(payload$crs$authority) && !is.null(payload$crs$srid)) {
+    pref <- paste0(payload$crs$authority, ":", payload$crs$srid)
+  }
+  pref <- pref %||%
+    payload$crs$srid %||%
+    payload$crs$wkt2_2019 %||%
+    payload$crs$input
+
+  tryCatch(sf::st_crs(pref), error = function(e) sf::st_crs(NA))
+}
+
+resolve_crs <- function(
+  conn,
+  table,
+  geom_col,
+  explicit = NULL,
+  warn_on_disagree = TRUE,
+  quiet_unknown = FALSE
+) {
+  if (!is.null(explicit)) {
+    return(sf::st_crs(explicit))
+  }
+
+  native <- read_native_crs(conn, table, geom_col)
+  comment <- parse_crs_comment(get_column_comment(conn, table, geom_col))
+  comment_crs <- crs_from_comment_payload(comment)
+
+  has_native <- !is.na(native)
+  has_comment <- !is.na(comment_crs)
+
+  if (
+    has_native &&
+      has_comment &&
+      warn_on_disagree &&
+      !crs_equal(native, comment_crs)
+  ) {
+    cli::cli_warn(
+      "CRS disagreement for {.val {table}}.{.val {geom_col}}: using native DuckDB CRS metadata."
+    )
+  }
+  if (has_native) {
+    return(native)
+  }
+  if (has_comment) {
+    return(comment_crs)
+  }
+
+  if (!quiet_unknown) {
+    cli::cli_warn(c(
+      "CRS could not be detected for {.val {table}}.{.val {geom_col}}.",
+      "i" = "This can happen when reading an older DuckDB storage file that was created before duckspatial persisted CRS metadata, or when the table has no CRS information.",
+      "i" = "Use {.arg crs} when opening the dataset, or rewrite the file using {.code ddbs_create_conn(..., storage_version = \"v1.5.0\")} to persist CRS natively."
+    ))
+  }
+
+  sf::st_crs(NA)
+}
+
+ddbs_duckdb_storage_tag <- function(conn) {
+  tags <- tryCatch(
+    DBI::dbGetQuery(
+      conn,
+      "SELECT tags FROM duckdb_databases() WHERE database_name = current_database()"
+    )$tags[[1]],
+    error = function(e) NULL
+  )
+
+  if (!is.data.frame(tags) || nrow(tags) == 0) {
+    return(NA_character_)
+  }
+
+  value <- tags$value[tags$key == "storage_version"]
+  if (length(value) == 0) {
+    return(NA_character_)
+  }
+
+  as.character(value[[1]])
+}
+
+ddbs_open_persistent <- function(
+  dbdir,
+  storage_version = duckspatial_storage_default(),
+  read_only = FALSE,
+  ...
+) {
+  storage_version <- match.arg(storage_version, duckspatial_storage_versions())
+  if (dbdir %in% c(":memory:", "memory")) {
+    conn <- DBI::dbConnect(
+      duckdb::duckdb(dbdir = ":memory:"),
+      geometry = "wk",
+      ...
+    )
+    attr(conn, "duckspatial_storage_mode") <- "memory"
+    return(conn)
+  }
+
+  is_new <- !file.exists(dbdir)
+  config <- list()
+  if (is_new && !identical(storage_version, "legacy")) {
+    config$storage_compatibility_version <- storage_version
+  }
+
+  conn <- DBI::dbConnect(
+    duckdb::duckdb(dbdir = dbdir, read_only = read_only, config = config),
+    geometry = "wk",
+    ...
+  )
+
+  actual <- ddbs_duckdb_storage_tag(conn)
+  requested <- if (identical(storage_version, "legacy")) {
+    NA_character_
+  } else {
+    paste0(storage_version, "+")
+  }
+  legacy_mode <- identical(storage_version, "legacy") ||
+    (!is.na(requested) && !identical(actual, requested))
+
+  if (
+    !identical(storage_version, "legacy") &&
+      isTRUE(legacy_mode) &&
+      !isTRUE(read_only)
+  ) {
+    cli::cli_warn(
+      c(
+        "Requested DuckDB storage {.val {storage_version}} but file storage is {.val {actual}}.",
+        "i" = "CRS persistence will use duckspatial-managed column-comment metadata for this compatibility connection."
+      ),
+      class = "duckspatial_storage_mismatch"
+    )
+  }
+
+  attr(conn, "db_file") <- dbdir
+  attr(conn, "duckspatial_storage") <- actual
+  attr(conn, "duckspatial_storage_mode") <- if (legacy_mode) {
+    "legacy"
+  } else {
+    storage_version
+  }
+  conn
+}

--- a/R/db_utils.R
+++ b/R/db_utils.R
@@ -198,6 +198,11 @@ ddbs_glimpse <- function(
 #' @template threads
 #' @template memory_limit_gb
 #' @param upgrade if TRUE, it upgrades the DuckDB extension to the latest version
+#' @param storage_version Storage compatibility for newly created persistent
+#'   DuckDB files. The default, `"v1.5.0"`, preserves CRS metadata in native
+#'   DuckDB `GEOMETRY` columns but requires DuckDB >= 1.5.0 to open the file.
+#'   Use `"legacy"` to create files readable by older DuckDB versions and
+#'   persist CRS metadata in duckspatial-managed column comments.
 #' @param ... Additional parameters to be passed to \code{\link[DBI]{dbConnect}}
 #'
 #' @returns A `duckdb_connection`
@@ -223,7 +228,10 @@ ddbs_create_conn <- function(
   threads = NULL, 
   memory_limit_gb = NULL,
   upgrade = FALSE,
+  storage_version = duckspatial_storage_default(),
   ...) {
+
+    storage_version <- match.arg(storage_version, duckspatial_storage_versions())
 
     if (!dbdir %in% c("tempdir", "memory") && !has_duckdb_file_extension(dbdir)) {
       cli::cli_abort(
@@ -239,12 +247,10 @@ ddbs_create_conn <- function(
     if(dbdir == 'tempdir'){
       
       db_path <- tempfile(pattern = 'duckspatial', fileext = '.duckdb')
-      conn <- duckdb::dbConnect(
-        duckdb::duckdb(
-          dbdir = db_path
-          #, bigint = "integer64" ## in case the data includes big int
-        ),
-        geometry = "wk",
+      conn <- ddbs_open_persistent(
+        db_path,
+        storage_version = storage_version,
+        read_only = FALSE,
         ...
       )
     } else if (dbdir == 'memory') {
@@ -257,9 +263,10 @@ ddbs_create_conn <- function(
         ...
       )
     } else {
-      conn <- duckdb::dbConnect(
-        duckdb::duckdb(dbdir = dbdir), 
-        geometry = "wk",
+      conn <- ddbs_open_persistent(
+        dbdir,
+        storage_version = storage_version,
+        read_only = FALSE,
         ...
       )
     }

--- a/R/db_utils.R
+++ b/R/db_utils.R
@@ -198,14 +198,23 @@ ddbs_glimpse <- function(
 #' @template threads
 #' @template memory_limit_gb
 #' @param upgrade if TRUE, it upgrades the DuckDB extension to the latest version
-#' @param storage_version Storage compatibility for newly created persistent
-#'   DuckDB files. The default, `"v1.5.0"` (**Native Persistence**), preserves 
-#'   CRS metadata in native DuckDB `GEOMETRY` columns but requires 
-#'   DuckDB >= 1.5.0 to open the file. Use `"legacy"` (**Metadata Fallback**) 
-#'   to create files readable by older DuckDB versions and persist CRS 
-#'   metadata in duckspatial-managed column comments (note that these comments 
-#'   are a duckspatial convention and not recognized by other spatial software).
 #' @param ... Additional parameters to be passed to \code{\link[DBI]{dbConnect}}
+#' @param duckdb_storage_version Storage compatibility for newly created persistent
+#'   native DuckDB files (\code{.duckdb}, \code{.db}, \code{.ddb}). See
+#'   \url{https://duckdb.org/docs/internals/storage} for more information on
+#'   DuckDB storage versions and compatibility.
+#'   \itemize{
+#'     \item \code{"v1.5.0"} (\strong{Native Spatial Storage}, Default): Preserves
+#'           CRS metadata in native DuckDB \code{GEOMETRY} columns. Requires
+#'           DuckDB >= 1.5.0 to open the file.
+#'     \item \code{"v1.0.0"} (\strong{Legacy Compatibility}): Creates
+#'           files readable by older DuckDB versions (>= 1.0.0). Persists CRS
+#'           metadata in duckspatial-managed column comments (a convention not
+#'           recognized by other spatial software).
+#'     \item \code{"latest"}: Use the highest storage version supported by your
+#'           installed DuckDB engine.
+#'   }
+#'   Other major version strings like \code{"v1.4.0"}, \code{"v1.3.0"}, etc., are also supported.
 #'
 #' @returns A `duckdb_connection`
 #' @export
@@ -230,10 +239,10 @@ ddbs_create_conn <- function(
   threads = NULL, 
   memory_limit_gb = NULL,
   upgrade = FALSE,
-  storage_version = duckspatial_storage_default(),
-  ...) {
+  ...,
+  duckdb_storage_version = duckspatial_storage_default()) {
 
-    storage_version <- match.arg(storage_version, duckspatial_storage_versions())
+    duckdb_storage_version <- match_duckdb_storage_version(duckdb_storage_version)
 
     if (!dbdir %in% c("tempdir", "memory") && !has_duckdb_file_extension(dbdir)) {
       cli::cli_abort(
@@ -251,7 +260,7 @@ ddbs_create_conn <- function(
       db_path <- tempfile(pattern = 'duckspatial', fileext = '.duckdb')
       conn <- ddbs_open_persistent(
         db_path,
-        storage_version = storage_version,
+        duckdb_storage_version = duckdb_storage_version,
         read_only = FALSE,
         ...
       )
@@ -267,7 +276,7 @@ ddbs_create_conn <- function(
     } else {
       conn <- ddbs_open_persistent(
         dbdir,
-        storage_version = storage_version,
+        duckdb_storage_version = duckdb_storage_version,
         read_only = FALSE,
         ...
       )

--- a/R/db_utils.R
+++ b/R/db_utils.R
@@ -199,10 +199,12 @@ ddbs_glimpse <- function(
 #' @template memory_limit_gb
 #' @param upgrade if TRUE, it upgrades the DuckDB extension to the latest version
 #' @param storage_version Storage compatibility for newly created persistent
-#'   DuckDB files. The default, `"v1.5.0"`, preserves CRS metadata in native
-#'   DuckDB `GEOMETRY` columns but requires DuckDB >= 1.5.0 to open the file.
-#'   Use `"legacy"` to create files readable by older DuckDB versions and
-#'   persist CRS metadata in duckspatial-managed column comments.
+#'   DuckDB files. The default, `"v1.5.0"` (**Native Persistence**), preserves 
+#'   CRS metadata in native DuckDB `GEOMETRY` columns but requires 
+#'   DuckDB >= 1.5.0 to open the file. Use `"legacy"` (**Metadata Fallback**) 
+#'   to create files readable by older DuckDB versions and persist CRS 
+#'   metadata in duckspatial-managed column comments (note that these comments 
+#'   are a duckspatial convention and not recognized by other spatial software).
 #' @param ... Additional parameters to be passed to \code{\link[DBI]{dbConnect}}
 #'
 #' @returns A `duckdb_connection`

--- a/R/db_utils.R
+++ b/R/db_utils.R
@@ -331,8 +331,13 @@ ddbs_stop_conn <- function(conn) {
     # Check if connection is correct
     dbConnCheck(conn)
 
-    # Disconnect from database
+    # Disconnect from database and shutdown driver
+    # Explicit driver shutdown is required on Windows to release file locks
+    drv <- conn@driver
     DBI::dbDisconnect(conn)
+    if (inherits(drv, "duckdb_driver")) {
+        duckdb::duckdb_shutdown(drv)
+    }
 
     return(invisible(TRUE))
 }

--- a/R/db_utils.R
+++ b/R/db_utils.R
@@ -193,8 +193,8 @@ ddbs_glimpse <- function(
 #' It creates a DuckDB connection, and then it installs and loads the
 #' spatial extension
 #'
-#' @param dbdir String. Either `"tempdir"`, `"memory"`, or file path with
-#' `.duckdb` or `.db` extension. Defaults to `"memory"`.
+#' @param dbdir String. Either `"tempdir"`, `"memory"`, or a DuckDB database
+#' file path with `.duckdb`, `.db`, or `.ddb` extension. Defaults to `"memory"`.
 #' @template threads
 #' @template memory_limit_gb
 #' @param upgrade if TRUE, it upgrades the DuckDB extension to the latest version
@@ -225,12 +225,10 @@ ddbs_create_conn <- function(
   upgrade = FALSE,
   ...) {
 
-    # 0. Handle errors
-    if (!dbdir %in% c("tempdir","memory")) {
-      ## get file extension
-      db_extension <- tools::file_ext(dbdir)
-      if (!db_extension %in% c("", "duckdb", "db"))
-        cli::cli_abort("dbdir should be <'tempdir'>, <'memory'>, or have <'.duckdb'> or <'.db'> extension.")
+    if (!dbdir %in% c("tempdir", "memory") && !has_duckdb_file_extension(dbdir)) {
+      cli::cli_abort(
+        "{.arg dbdir} should be {.val tempdir}, {.val memory}, or a file path with {.file .duckdb}, {.file .db}, or {.file .ddb} extension."
+      )
     }
 
     assert_threads(threads)

--- a/R/db_utils.R
+++ b/R/db_utils.R
@@ -333,6 +333,7 @@ ddbs_stop_conn <- function(conn) {
 
     # Disconnect from database and shutdown driver
     # Explicit driver shutdown is required on Windows to release file locks
+    ddbs_checkpoint_if_possible(conn)
     drv <- conn@driver
     DBI::dbDisconnect(conn)
     if (inherits(drv, "duckdb_driver")) {

--- a/R/ddbs_crs.R
+++ b/R/ddbs_crs.R
@@ -68,18 +68,16 @@ ddbs_crs.tbl_duckdb_connection <- function(x, ...) {
   if (!is.null(remote_table)) {
     crs_data <- tryCatch({
       geom_name <- get_geom_name(conn, remote_table)
-      res <- DBI::dbGetQuery(
-        conn, glue::glue("SELECT ST_CRS({geom_name}) AS crs FROM {remote_table} LIMIT 1;")
+      resolve_crs(
+        conn,
+        remote_table,
+        geom_name,
+        quiet_unknown = TRUE
       )
-      if (nrow(res) > 0 && !is.na(res$crs[1])) {
-          res$crs[1]
-      } else {
-          NULL
-      }
     }, error = function(e) NULL)
 
-    if (!is.null(crs_data) && length(crs_data) > 0 && !is.na(crs_data)) {
-      return(sf::st_crs(crs_data))
+    if (!is.null(crs_data) && !is.na(crs_data)) {
+      return(crs_data)
     }
   }
 
@@ -188,14 +186,12 @@ ddbs_crs.character <- function(x, conn, ...) {
     ## Get CRS from the table
     crs_data <- tryCatch({
       geom_name <- get_geom_name(conn, x_list$query_name)
-      res <- DBI::dbGetQuery(
-        conn, glue::glue("SELECT ST_CRS({geom_name}) AS crs FROM {x_list$query_name} LIMIT 1;")
+      resolve_crs(
+        conn,
+        x_list$query_name,
+        geom_name,
+        quiet_unknown = TRUE
       )
-      if (nrow(res) > 0 && !is.na(res$crs[1])) {
-        res$crs[1]
-      } else {
-        NULL
-      }
     }, error = function(e) {
       NULL
     })
@@ -224,15 +220,15 @@ ddbs_crs.character <- function(x, conn, ...) {
       }
     
       cli::cli_warn(c(
-        "CRS could not be auto-detected for {.val {name}}.",
-        "i" = "This typically occurs when reopening a persistent DuckDB database (which natively drops CRS metadata on close) or reading data lacking a CRS.",
+        "CRS could not be detected for {.val {name}}.",
+        "i" = "This can happen when reading an older DuckDB storage file that was created before duckspatial persisted CRS metadata, or when the table has no CRS information.",
         "i" = "Use {.code as_duckspatial_df(x, crs = ...)} or {.code ddbs_open_dataset(path, crs = ...)} to set the CRS explicitly."
       ))
       return(sf::st_crs(NA))
     }
 
     # 2. Return CRS
-    return(sf::st_crs(crs_data))
+    return(crs_data)
 }
 
 #' @export

--- a/R/ddbs_crs.R
+++ b/R/ddbs_crs.R
@@ -132,8 +132,8 @@ ddbs_crs.tbl_duckdb_connection <- function(x, ...) {
   # Fallback: return NA CRS
   cli::cli_warn(c(
     "Could not auto-detect CRS for {.cls tbl_duckdb_connection} object.",
-    "i" = "The object may not be a view created from a spatial file.",
-    "i" = "Use {.code as_duckspatial_df(x, crs = ...)} to set CRS explicitly."
+    "i" = "This typically occurs when reopening a persistent DuckDB database (which natively drops CRS metadata on close) or reading data lacking a CRS.",
+    "i" = "Use {.code as_duckspatial_df(x, crs = ...)} to set the CRS explicitly."
   ))
   sf::st_crs(NA)
 }
@@ -188,9 +188,14 @@ ddbs_crs.character <- function(x, conn, ...) {
     ## Get CRS from the table
     crs_data <- tryCatch({
       geom_name <- get_geom_name(conn, x_list$query_name)
-      DBI::dbGetQuery(
+      res <- DBI::dbGetQuery(
         conn, glue::glue("SELECT ST_CRS({geom_name}) AS crs FROM {x_list$query_name} LIMIT 1;")
-      ) |> as.character()
+      )
+      if (nrow(res) > 0 && !is.na(res$crs[1])) {
+        res$crs[1]
+      } else {
+        NULL
+      }
     }, error = function(e) {
       NULL
     })
@@ -218,7 +223,11 @@ ddbs_crs.character <- function(x, conn, ...) {
          }
       }
     
-      cli::cli_warn("CRS could not be auto-detected.")
+      cli::cli_warn(c(
+        "CRS could not be auto-detected for {.val {name}}.",
+        "i" = "This typically occurs when reopening a persistent DuckDB database (which natively drops CRS metadata on close) or reading data lacking a CRS.",
+        "i" = "Use {.code as_duckspatial_df(x, crs = ...)} or {.code ddbs_open_dataset(path, crs = ...)} to set the CRS explicitly."
+      ))
       return(sf::st_crs(NA))
     }
 

--- a/R/ddbs_crs.R
+++ b/R/ddbs_crs.R
@@ -59,6 +59,30 @@ ddbs_crs.tbl_duckdb_connection <- function(x, ...) {
   # Try to auto-detect CRS from view SQL (for duckdbfs::open_dataset and similar)
   conn <- dbplyr::remote_con(x)
   
+  # Try to use ST_CRS() first if we have a valid table name
+  remote_table <- tryCatch({
+    rem_name <- dbplyr::remote_name(x)
+    if (is.null(rem_name)) NULL else as.character(rem_name)
+  }, error = function(e) NULL)
+
+  if (!is.null(remote_table)) {
+    crs_data <- tryCatch({
+      geom_name <- get_geom_name(conn, remote_table)
+      res <- DBI::dbGetQuery(
+        conn, glue::glue("SELECT ST_CRS({geom_name}) AS crs FROM {remote_table} LIMIT 1;")
+      )
+      if (nrow(res) > 0 && !is.na(res$crs[1])) {
+          res$crs[1]
+      } else {
+          NULL
+      }
+    }, error = function(e) NULL)
+
+    if (!is.null(crs_data) && length(crs_data) > 0 && !is.na(crs_data)) {
+      return(sf::st_crs(crs_data))
+    }
+  }
+
   # Strategy 1: Try to get view SQL from duckdb_views()
   view_sql <- tryCatch({
     table_name <- dbplyr::remote_name(x)

--- a/R/ddbs_crs.R
+++ b/R/ddbs_crs.R
@@ -130,7 +130,7 @@ ddbs_crs.tbl_duckdb_connection <- function(x, ...) {
   # Fallback: return NA CRS
   cli::cli_warn(c(
     "Could not auto-detect CRS for {.cls tbl_duckdb_connection} object.",
-    "i" = "This typically occurs when reopening a persistent DuckDB database (which natively drops CRS metadata on close) or reading data lacking a CRS.",
+    "i" = "This typically occurs when reopening a persistent DuckDB database created without recoverable CRS metadata (for example, pre-1.5 files without duckspatial comments) or when the table/file has an unknown or missing CRS.",
     "i" = "Use {.code as_duckspatial_df(x, crs = ...)} to set the CRS explicitly."
   ))
   sf::st_crs(NA)

--- a/R/ddbs_options.R
+++ b/R/ddbs_options.R
@@ -15,6 +15,9 @@
 #'     \item \code{"sf"}: Eagerly collected sf object (uses memory)
 #'   }
 #'   If \code{NULL} (the default), the existing option is not changed.
+#' @param duckdb_storage_version Character. The default DuckDB storage compatibility version
+#'   for newly created database files. See \url{https://duckdb.org/docs/internals/storage}
+#'   for details.
 #'
 #' @return Invisibly returns a list containing the currently set options.
 #' @export
@@ -30,7 +33,7 @@
 #' # Check current settings
 #' ddbs_options()
 #' }
-ddbs_options <- function(output_type = NULL, mode = NULL) {
+ddbs_options <- function(output_type = NULL, mode = NULL, duckdb_storage_version = NULL) {
   
   # 1. SETTER logic
   if (!is.null(output_type)) {
@@ -52,15 +55,22 @@ ddbs_options <- function(output_type = NULL, mode = NULL) {
     }
     options(duckspatial.mode = mode)
   }
+
+  if (!is.null(duckdb_storage_version)) {
+    # Use internal helper to validate
+    duckdb_storage_version <- match_duckdb_storage_version(duckdb_storage_version)
+    options(duckspatial.duckdb_storage_version = duckdb_storage_version)
+  }
   
   # 2. GETTER logic (Always retrieve current state)
   op <- list(
     duckspatial.output_type = getOption("duckspatial.output_type"),
-    duckspatial.mode = getOption("duckspatial.mode")
+    duckspatial.mode = getOption("duckspatial.mode"),
+    duckspatial.duckdb_storage_version = getOption("duckspatial.duckdb_storage_version")
   )
   
   # If we set a value, return invisibly. If just checking, return visibly.
-  if (all(is.null(output_type), is.null(mode))) {
+  if (all(is.null(output_type), is.null(mode), is.null(duckdb_storage_version))) {
     op
   } else {
     invisible(op)
@@ -87,9 +97,11 @@ ddbs_sitrep <- function() {
   
   out_type <- getOption("duckspatial.output_type", "duckspatial_df (default)")
   mode     <- getOption("duckspatial.mode", "duckspatial (default)")
+  storage_ver <- getOption("duckspatial.duckdb_storage_version", "v1.5.0")
   cli::cli_ul()
   cli::cli_li("Output Type: {.val {out_type}}")
   cli::cli_li("Mode: {.val {mode}}")
+  cli::cli_li("DuckDB Storage Version: {.val {storage_ver}}")
   cli::cli_end()
   
   # 2. Connection Status

--- a/R/duckspatial_df.R
+++ b/R/duckspatial_df.R
@@ -72,9 +72,23 @@ is_duckspatial_df <- function(x) {
 
 #' Convert objects to duckspatial_df
 #'
+#' @description
+#' `as_duckspatial_df()` creates a lazy spatial data frame (`duckspatial_df`) from 
+#' various inputs. When `x` is a table name (character) or an existing DuckDB 
+#' table (`tbl_duckdb_connection`), the function creates a zero-copy representation 
+#' of the data directly from the database without loading it into memory. This is 
+#' the canonical way to "register" or wrap existing persistent spatial tables.
+#' 
+#' **Important Note on CRS Persistence:** Due to an upstream limitation in DuckDB 
+#' (as of v1.5), CRS metadata is not reliably persisted when a database is closed 
+#' and reopened. When reopening a persistent `.duckdb` database, `as_duckspatial_df()`
+#' may not be able to auto-detect the CRS, and you will need to provide it manually 
+#' via the `crs` argument.
+#'
 #' @param x Object to convert (sf, tbl_lazy, data.frame, or table name)
 #' @param conn DuckDB connection (required for character table names)
-#' @param crs CRS object or string (auto-detected from sf objects)
+#' @param crs CRS object or string (auto-detected from sf objects, but must be 
+#'   provided manually when reopening persistent DuckDB tables)
 #' @param geom_col Geometry column name (default: "geom")
 #' @param ... Additional arguments passed to methods:
 #'   \describe{

--- a/R/duckspatial_df.R
+++ b/R/duckspatial_df.R
@@ -79,12 +79,16 @@ is_duckspatial_df <- function(x) {
 #' of the data directly from the database without loading it into memory. This is 
 #' the canonical way to "register" or wrap existing persistent spatial tables.
 #' 
-#' **CRS Persistence:** `duckspatial`` reads native DuckDB 1.5 CRS metadata and, for compatibility files written by duckspatial, CRS metadata stored in duckspatial-managed column comments. DuckDB files saved in pre-1.5 format without duckspatial-managed comments will not have CRS information and will default to NA with a warning. To ensure CRS persistence, use DuckDB 1.5+ and  when creating DuckDB database files.
+#' **CRS Persistence:** `duckspatial` reads native DuckDB 1.5.0+ CRS metadata 
+#' and, for compatibility with files written by older versions of `duckspatial`, 
+#' CRS metadata stored in column comments. DuckDB files saved in pre-1.5.0 
+#' format without `duckspatial`-managed comments will not have CRS information 
+#' and will default to `NA` with a warning.
 #'
 #' @param x Object to convert (sf, tbl_lazy, data.frame, or table name)
 #' @param conn DuckDB connection (required for character table names)
-#' @param crs CRS object or string (auto-detected from sf objects, but must be 
-#'   provided manually when reopening persistent DuckDB tables)
+#' @param crs CRS object or string. Auto-detected from `sf` objects and 
+#'   persistent DuckDB tables.
 #' @param geom_col Geometry column name (default: "geom")
 #' @param ... Additional arguments passed to methods:
 #'   \describe{

--- a/R/duckspatial_df.R
+++ b/R/duckspatial_df.R
@@ -79,11 +79,7 @@ is_duckspatial_df <- function(x) {
 #' of the data directly from the database without loading it into memory. This is 
 #' the canonical way to "register" or wrap existing persistent spatial tables.
 #' 
-#' **Important Note on CRS Persistence:** Due to an upstream limitation in DuckDB 
-#' (as of v1.5), CRS metadata is not reliably persisted when a database is closed 
-#' and reopened. When reopening a persistent `.duckdb` database, `as_duckspatial_df()`
-#' may not be able to auto-detect the CRS, and you will need to provide it manually 
-#' via the `crs` argument.
+#' **CRS Persistence:** `duckspatial`` reads native DuckDB 1.5 CRS metadata and, for compatibility files written by duckspatial, CRS metadata stored in duckspatial-managed column comments. DuckDB files saved in pre-1.5 format without duckspatial-managed comments will not have CRS information and will default to NA with a warning. To ensure CRS persistence, use DuckDB 1.5+ and  when creating DuckDB database files.
 #'
 #' @param x Object to convert (sf, tbl_lazy, data.frame, or table name)
 #' @param conn DuckDB connection (required for character table names)
@@ -100,6 +96,7 @@ is_duckspatial_df <- function(x) {
 #' @return A duckspatial_df object
 #' @export
 as_duckspatial_df <- function(x, conn = NULL, crs = NULL, geom_col = NULL, ...) {
+  ddbs_assert_duckdb_crs_support()
   UseMethod("as_duckspatial_df")
 }
 

--- a/R/io_open_dataset.R
+++ b/R/io_open_dataset.R
@@ -4,11 +4,14 @@
 #' native Parquet reader, returning a \code{duckspatial_df} object for lazy processing.
 #'
 #' @param path Path to spatial file. Supports Parquet (`.parquet`, with optional GeoParquet metadata),
-#'   GeoJSON, GeoPackage, Shapefile, FlatGeoBuf, OSM PBF, and other GDAL-supported formats.
+#'   GeoJSON, GeoPackage, Shapefile, FlatGeoBuf, OSM PBF, DuckDB database files
+#'   (`.duckdb`, `.db`, and `.ddb`), and other GDAL-supported formats.
 #' @param crs Coordinate reference system. Can be an EPSG code (e.g., 4326),
 #'   a CRS string, or an \code{sf} crs object. If \code{NULL} (default),
 #'   attempts to auto-detect from the file.
-#' @param layer Layer name or index to read (ST_Read only). Default is NULL (first layer).
+#' @param layer Layer name or index to read (ST_Read). For DuckDB database
+#'   files, this is required and specifies the table name to read. Default is
+#'   NULL (first layer for ST_Read).
 #' @param geom_col Name of the geometry column. Default is \code{NULL}, which attempts 
 #'   auto-detection.
 #' @param conn DuckDB connection to use. If NULL, uses the default connection.
@@ -94,6 +97,44 @@ ddbs_open_dataset <- function(path,
   # Check for dedicated readers dispatch
   is_dedicated_shp <- (fmt == "shp" && read_shp_mode == "ST_ReadSHP")
   is_dedicated_osm <- (fmt == "osm.pbf" || grepl("\\.osm\\.pbf$", path)) && read_osm_mode == "ST_ReadOSM"
+  
+  # Support opening DuckDB files natively for explicit DuckDB file extensions.
+  # Magic bytes are still the source of truth for whether a candidate is valid.
+  duckdb_ext <- has_duckdb_file_extension(path)
+  duckdb_info <- duckdb_file_info(path)
+  if (duckdb_ext) {
+    if (!duckdb_info$exists) {
+      cli::cli_abort("File {.file {path}} does not exist.")
+    }
+
+    if (!isTRUE(duckdb_info$valid)) {
+      if (isTRUE(duckdb_info$empty) || tolower(tools::file_ext(path)) %in% c("duckdb", "ddb")) {
+        cli::cli_abort(c(
+          "File {.file {path}} is not a valid DuckDB database.",
+          "x" = "The file is missing the DuckDB magic bytes."
+        ))
+      }
+      # Non-DuckDB .db files are common in the wild. Let GDAL/ST_Read attempt
+      # them instead of treating the extension alone as authoritative.
+    } else {
+      if (is.null(layer)) {
+        cli::cli_abort(c(
+          "You must specify the {.arg layer} (table name) when opening a DuckDB database file.",
+          "i" = "Example: {.code ddbs_open_dataset('{path}', layer = 'my_table')}"
+        ))
+      }
+
+      local_conn <- ddbs_create_conn(path)
+      name_list <- get_query_name(layer)
+
+      if (!table_exists(local_conn, name_list$table_name, name_list$schema_name)) {
+        ddbs_stop_conn(local_conn)
+        cli::cli_abort("Table {.val {layer}} is not present in DuckDB database {.file {path}}.")
+      }
+
+      return(as_duckspatial_df(layer, conn = local_conn, crs = crs_override, geom_col = geom_col))
+    }
+  }
     
   # Helper for temporary table construction
   # As for duckdb v1.5 we cannot work with views as the geometry type is not recognized

--- a/R/io_open_dataset.R
+++ b/R/io_open_dataset.R
@@ -8,7 +8,10 @@
 #'   (`.duckdb`, `.db`, and `.ddb`), and other GDAL-supported formats.
 #' @param crs Coordinate reference system. Can be an EPSG code (e.g., 4326),
 #'   a CRS string, or an \code{sf} crs object. If \code{NULL} (default),
-#'   attempts to auto-detect from the file.
+#'   attempts to auto-detect from the file. **Important:** Due to an upstream 
+#'   limitation in DuckDB (as of v1.5), CRS metadata is not reliably persisted 
+#'   in `.duckdb` files. When opening tables from persistent DuckDB files, you 
+#'   must provide this argument manually.
 #' @param layer Layer name or index to read (ST_Read). For DuckDB database
 #'   files, this is required and specifies the table name to read. Default is
 #'   NULL (first layer for ST_Read).

--- a/R/io_open_dataset.R
+++ b/R/io_open_dataset.R
@@ -134,14 +134,19 @@ ddbs_open_dataset <- function(path,
           invokeRestart("muffleWarning")
         }
       )
-      name_list <- get_query_name(layer)
 
-      if (!table_exists(local_conn, name_list$table_name, name_list$schema_name)) {
+      result <- tryCatch({
+        name_list <- get_query_name(layer)
+        if (!table_exists(local_conn, name_list$table_name, name_list$schema_name)) {
+          cli::cli_abort("Table {.val {layer}} is not present in DuckDB database {.file {path}}.")
+        }
+        as_duckspatial_df(layer, conn = local_conn, crs = crs_override, geom_col = geom_col)
+      }, error = function(e) {
         ddbs_stop_conn(local_conn)
-        cli::cli_abort("Table {.val {layer}} is not present in DuckDB database {.file {path}}.")
-      }
+        stop(e)
+      })
 
-      return(as_duckspatial_df(layer, conn = local_conn, crs = crs_override, geom_col = geom_col))
+      return(result)
     }
   }
     

--- a/R/io_open_dataset.R
+++ b/R/io_open_dataset.R
@@ -8,10 +8,9 @@
 #'   (`.duckdb`, `.db`, and `.ddb`), and other GDAL-supported formats.
 #' @param crs Coordinate reference system. Can be an EPSG code (e.g., 4326),
 #'   a CRS string, or an \code{sf} crs object. If \code{NULL} (default),
-#'   attempts to auto-detect from the file. **Important:** Due to an upstream 
-#'   limitation in DuckDB (as of v1.5), CRS metadata is not reliably persisted 
-#'   in `.duckdb` files. When opening tables from persistent DuckDB files, you 
-#'   must provide this argument manually.
+#'   attempts to auto-detect from the file, including native DuckDB CRS metadata
+#'   and duckspatial-managed column-comment metadata for compatibility
+#'   `.duckdb` files.
 #' @param layer Layer name or index to read (ST_Read). For DuckDB database
 #'   files, this is required and specifies the table name to read. Default is
 #'   NULL (first layer for ST_Read).
@@ -77,6 +76,8 @@ ddbs_open_dataset <- function(path,
                                    gdal_allowed_drivers = NULL,
                                    gdal_open_options = NULL) {
   
+  ddbs_assert_duckdb_crs_support()
+
   # Capture the call for error reporting
   fn_call <- rlang::current_call()
   crs_override <- crs
@@ -127,7 +128,12 @@ ddbs_open_dataset <- function(path,
         ))
       }
 
-      local_conn <- ddbs_create_conn(path)
+      local_conn <- withCallingHandlers(
+        ddbs_create_conn(path),
+        duckspatial_storage_mismatch = function(w) {
+          invokeRestart("muffleWarning")
+        }
+      )
       name_list <- get_query_name(layer)
 
       if (!table_exists(local_conn, name_list$table_name, name_list$schema_name)) {

--- a/R/io_write.R
+++ b/R/io_write.R
@@ -2,6 +2,12 @@
 #'
 #' This function writes a Simple Features (SF) object into a DuckDB database as a new table.
 #' The table is created in the specified schema of the DuckDB database.
+#' 
+#' **Important Note on CRS Persistence:** Due to an upstream limitation in DuckDB 
+#' (as of v1.5), CRS metadata is not reliably persisted when a `.duckdb` database 
+#' is closed and reopened. If you need to persistently save spatial data and 
+#' seamlessly retain CRS metadata across sessions, using [ddbs_write_dataset()] 
+#' to save to a GeoParquet (`.parquet`) file is strongly recommended.
 #'
 #' @template conn
 #' @param data A \code{sf} object to write to the DuckDB database, or the path to

--- a/R/io_write.R
+++ b/R/io_write.R
@@ -61,6 +61,7 @@ ddbs_write_table <- function(
     # 1. Checks
     ## Check if connection is correct
     dbConnCheck(conn)
+    input_crs <- ddbs_input_crs_for_write(data, conn)
 
     ## Handle temp_view
     if (temp_view) {
@@ -113,6 +114,13 @@ ddbs_write_table <- function(
                 if (isFALSE(quiet)) {
                     cli::cli_alert_success("Table {name_list$query_name} imported via {import_result$method}")
                 }
+                geom_col <- tryCatch(get_geom_name(conn, name_list$query_name), error = function(e) NULL)
+                ddbs_write_legacy_crs_comment_if_needed(
+                    conn,
+                    name_list$query_name,
+                    geom_col = geom_col,
+                    crs = input_crs
+                )
                 return(invisible(TRUE))
             }
         }
@@ -157,7 +165,7 @@ ddbs_write_table <- function(
         data_df[[geom_name]] <- wkb_data  # Ensure raw data is preserved
 
         ## Get the CRS, and define the geometry type for duckdb
-        geom_field <- get_geometry_type_duckdb(data)
+        geom_field <- get_geometry_type_duckdb(data, conn)
 
         ## Warn if no CRS was found in the input data
         if (geom_field == "GEOMETRY") {
@@ -178,6 +186,12 @@ ddbs_write_table <- function(
             ALTER TABLE {name_list$query_name}
             ALTER COLUMN {geom_name} SET DATA TYPE {geom_field} USING ST_GeomFromWKB({geom_name});
         "))
+        ddbs_write_legacy_crs_comment_if_needed(
+            conn,
+            name_list$query_name,
+            geom_col = geom_name,
+            crs = input_crs
+        )
         # duckdb::duckdb_unregister(conn, "temp_view") |> on.exit()
         
 
@@ -212,6 +226,11 @@ ddbs_write_table <- function(
             DBI::dbExecute(
                 conn,
                 glue::glue("CREATE TABLE {name_list$query_name} AS SELECT * FROM ST_Read('{data}')")
+            )
+            ddbs_write_legacy_crs_comment_if_needed(
+                conn,
+                name_list$query_name,
+                crs = input_crs
             )
         }
     }

--- a/R/io_write.R
+++ b/R/io_write.R
@@ -3,11 +3,11 @@
 #' This function writes a Simple Features (SF) object into a DuckDB database as a new table.
 #' The table is created in the specified schema of the DuckDB database.
 #' 
-#' **Important Note on CRS Persistence:** Due to an upstream limitation in DuckDB 
-#' (as of v1.5), CRS metadata is not reliably persisted when a `.duckdb` database 
-#' is closed and reopened. If you need to persistently save spatial data and 
-#' seamlessly retain CRS metadata across sessions, using [ddbs_write_dataset()] 
-#' to save to a GeoParquet (`.parquet`) file is strongly recommended.
+#' **CRS Persistence:** `duckspatial` ensures CRS metadata is retained across 
+#' sessions using two strategies: **Native Persistence** (for DuckDB 1.5.0+ 
+#' databases) and **Metadata Fallback** (using column comments for older 
+#' database versions). For file-based spatial data interchange, 
+#' [ddbs_write_dataset()] to GeoParquet (`.parquet`) is recommended.
 #'
 #' @template conn
 #' @param data A \code{sf} object to write to the DuckDB database, or the path to

--- a/R/io_write.R
+++ b/R/io_write.R
@@ -3,11 +3,11 @@
 #' This function writes a Simple Features (SF) object into a DuckDB database as a new table.
 #' The table is created in the specified schema of the DuckDB database.
 #' 
-#' **CRS Persistence:** `duckspatial` ensures CRS metadata is retained across 
-#' sessions using two strategies: **Native Persistence** (for DuckDB 1.5.0+ 
-#' databases) and **Metadata Fallback** (using column comments for older 
+#' **CRS Persistence:** \code{duckspatial} ensures CRS metadata is retained across 
+#' sessions using two strategies: \strong{Native Spatial Storage} (for DuckDB 1.5.0+ 
+#' databases) and \strong{Legacy Compatibility} (using column comments for older 
 #' database versions). For file-based spatial data interchange, 
-#' [ddbs_write_dataset()] to GeoParquet (`.parquet`) is recommended.
+#' [ddbs_write_dataset()] to GeoParquet (\code{.parquet}) is recommended.
 #'
 #' @template conn
 #' @param data A \code{sf} object to write to the DuckDB database, or the path to

--- a/R/io_write_dataset.R
+++ b/R/io_write_dataset.R
@@ -3,6 +3,11 @@
 #' Writes spatial data to disk using DuckDB's `COPY` command. Supports Parquet (native) 
 #' and various GDAL spatial formats. Format is auto-detected from file extension for 
 #' common formats, or can be specified explicitly via `gdal_driver`.
+#' 
+#' **Recommendation:** If you need to persistently save spatial data and reliably retain 
+#' Coordinate Reference System (CRS) metadata across sessions, **GeoParquet (`.parquet`) 
+#' is the recommended format.** DuckDB's native `.duckdb` database format currently 
+#' drops CRS metadata upon closing.
 #'
 #' @param data A `duckspatial_df`, `tbl_lazy` (DuckDB), or `sf` object.
 #' @param path Path to output file.

--- a/R/io_write_dataset.R
+++ b/R/io_write_dataset.R
@@ -5,11 +5,11 @@
 #' and `.ddb` paths. Format is auto-detected from file extension for common
 #' formats, or can be specified explicitly via `gdal_driver`.
 #' 
-#' Persistent DuckDB database files created by duckspatial use DuckDB storage
-#' compatibility version `"v1.5.0"` by default so CRS metadata is retained in
-#' native `GEOMETRY` columns. These files require DuckDB >= 1.5.0 to open; use
-#' `storage_version = "legacy"` when the output must be readable by older
-#' DuckDB versions.
+#' Persistent DuckDB database files created by duckspatial use **Native 
+#' Persistence** (`storage_version = "v1.5.0"`) by default so CRS metadata is 
+#' retained in native `GEOMETRY` columns. These files require DuckDB >= 1.5.0 
+#' to open; use **Metadata Fallback** (`storage_version = "legacy"`) when the 
+#' output must be readable by older DuckDB versions.
 #'
 #' @param data A `duckspatial_df`, `tbl_lazy` (DuckDB), or `sf` object.
 #' @param path Path to output file.
@@ -40,9 +40,12 @@
 #' @param crs Output CRS (e.g., "EPSG:4326"). Passed to GDAL as `SRS` option. Ignored for Parquet.
 #' @param layer Table name for native DuckDB database output.
 #' @param storage_version Storage compatibility for newly created DuckDB
-#'   database output. The default, `"v1.5.0"`, preserves CRS natively but
-#'   requires DuckDB >= 1.5.0 to open the file. Use `"legacy"` to store CRS
-#'   metadata in duckspatial-managed column comments for older DuckDB readers.
+#'   database output. The default, `"v1.5.0"` (**Native Persistence**), 
+#'   preserves CRS natively but requires DuckDB >= 1.5.0 to open the file. 
+#'   Use `"legacy"` (**Metadata Fallback**) to store CRS metadata in 
+#'   duckspatial-managed column comments for older DuckDB readers (note that 
+#'   these comments are a duckspatial convention and not recognized by other 
+#'   spatial software).
 #' @param options Named list of additional options passed to `COPY`.
 #' @param partitioning Character vector of columns to partition by (Parquet/CSV only).
 #' @param parquet_compression Compression codec for Parquet.

--- a/R/io_write_dataset.R
+++ b/R/io_write_dataset.R
@@ -6,10 +6,10 @@
 #' formats, or can be specified explicitly via `gdal_driver`.
 #' 
 #' Persistent DuckDB database files created by duckspatial use **Native 
-#' Persistence** (`storage_version = "v1.5.0"`) by default so CRS metadata is 
+#' Spatial Storage** (`storage_version = "v1.5.0"`) by default so CRS metadata is 
 #' retained in native `GEOMETRY` columns. These files require DuckDB >= 1.5.0 
-#' to open; use **Metadata Fallback** (`storage_version = "legacy"`) when the 
-#' output must be readable by older DuckDB versions.
+#' to open; use **Legacy Compatibility** (`storage_version = "v1.0.0"`) 
+#' when the output must be readable by older DuckDB versions.
 #'
 #' @param data A `duckspatial_df`, `tbl_lazy` (DuckDB), or `sf` object.
 #' @param path Path to output file.
@@ -39,19 +39,28 @@
 #' @param overwrite Logical. If `TRUE`, overwrites existing file.
 #' @param crs Output CRS (e.g., "EPSG:4326"). Passed to GDAL as `SRS` option. Ignored for Parquet.
 #' @param layer Table name for native DuckDB database output.
-#' @param storage_version Storage compatibility for newly created DuckDB
-#'   database output. The default, `"v1.5.0"` (**Native Persistence**), 
-#'   preserves CRS natively but requires DuckDB >= 1.5.0 to open the file. 
-#'   Use `"legacy"` (**Metadata Fallback**) to store CRS metadata in 
-#'   duckspatial-managed column comments for older DuckDB readers (note that 
-#'   these comments are a duckspatial convention and not recognized by other 
-#'   spatial software).
 #' @param options Named list of additional options passed to `COPY`.
 #' @param partitioning Character vector of columns to partition by (Parquet/CSV only).
 #' @param parquet_compression Compression codec for Parquet.
 #' @param parquet_row_group_size Row group size for Parquet.
 #' @param layer_creation_options GDAL layer creation options.
 #' @template quiet
+#' @param duckdb_storage_version Storage compatibility for newly created native
+#'   DuckDB database files (\code{.duckdb}, \code{.db}, \code{.ddb}). See
+#'   \url{https://duckdb.org/docs/internals/storage} for more information on
+#'   DuckDB storage versions and compatibility.
+#'   \itemize{
+#'     \item \code{"v1.5.0"} (\strong{Native Spatial Storage}, Default): Preserves
+#'           CRS metadata in native DuckDB \code{GEOMETRY} columns. Requires
+#'           DuckDB >= 1.5.0 to open the file.
+#'     \item \code{"v1.0.0"} (\strong{Legacy Compatibility}): Creates
+#'           files readable by older DuckDB versions (>= 1.0.0). Persists CRS
+#'           metadata in duckspatial-managed column comments (a convention not
+#'           recognized by other spatial software).
+#'     \item \code{"latest"}: Use the highest storage version supported by your
+#'           installed DuckDB engine.
+#'   }
+#'   Other major version strings like \code{"v1.4.0"}, \code{"v1.3.0"}, etc., are also supported.
 #'
 #' @return The `path` invisibly.
 #' 
@@ -101,15 +110,15 @@ ddbs_write_dataset <- function(
     overwrite = FALSE,
     crs = NULL,
     layer = "spatial",
-    storage_version = duckspatial_storage_default(),
     options = list(),
     partitioning = if (inherits(data, c("tbl_lazy", "duckspatial_df"))) dplyr::group_vars(data) else NULL,
     parquet_compression = NULL,
     parquet_row_group_size = NULL,
     layer_creation_options = NULL,
-    quiet = FALSE
+    quiet = FALSE,
+    duckdb_storage_version = duckspatial_storage_default()
 ) {
-  storage_version <- match.arg(storage_version, duckspatial_storage_versions())
+  duckdb_storage_version <- match_duckdb_storage_version(duckdb_storage_version)
   
   # 1. Resolve connection
   if (is.null(conn)) {
@@ -222,7 +231,7 @@ ddbs_write_dataset <- function(
       layer = layer,
       overwrite = TRUE,
       crs = crs,
-      storage_version = storage_version,
+      duckdb_storage_version = duckdb_storage_version,
       quiet = quiet
     ))
   }
@@ -481,10 +490,10 @@ ddbs_write_duckdb_dataset <- function(
   layer,
   overwrite,
   crs,
-  storage_version,
+  duckdb_storage_version,
   quiet
 ) {
-  target_conn <- ddbs_create_conn(path, storage_version = storage_version)
+  target_conn <- ddbs_create_conn(path, duckdb_storage_version = duckdb_storage_version)
   on.exit(ddbs_stop_conn(target_conn), add = TRUE)
 
   if (!is.null(crs)) {

--- a/R/io_write_dataset.R
+++ b/R/io_write_dataset.R
@@ -1,13 +1,15 @@
 #' Write spatial dataset to disk
 #'
-#' Writes spatial data to disk using DuckDB's `COPY` command. Supports Parquet (native) 
-#' and various GDAL spatial formats. Format is auto-detected from file extension for 
-#' common formats, or can be specified explicitly via `gdal_driver`.
+#' Writes spatial data to disk using DuckDB's `COPY` command for Parquet and
+#' GDAL spatial formats, or as a native DuckDB database for `.duckdb`, `.db`,
+#' and `.ddb` paths. Format is auto-detected from file extension for common
+#' formats, or can be specified explicitly via `gdal_driver`.
 #' 
-#' **Recommendation:** If you need to persistently save spatial data and reliably retain 
-#' Coordinate Reference System (CRS) metadata across sessions, **GeoParquet (`.parquet`) 
-#' is the recommended format.** DuckDB's native `.duckdb` database format currently 
-#' drops CRS metadata upon closing.
+#' Persistent DuckDB database files created by duckspatial use DuckDB storage
+#' compatibility version `"v1.5.0"` by default so CRS metadata is retained in
+#' native `GEOMETRY` columns. These files require DuckDB >= 1.5.0 to open; use
+#' `storage_version = "legacy"` when the output must be readable by older
+#' DuckDB versions.
 #'
 #' @param data A `duckspatial_df`, `tbl_lazy` (DuckDB), or `sf` object.
 #' @param path Path to output file.
@@ -36,6 +38,11 @@
 #' @template conn_null
 #' @param overwrite Logical. If `TRUE`, overwrites existing file.
 #' @param crs Output CRS (e.g., "EPSG:4326"). Passed to GDAL as `SRS` option. Ignored for Parquet.
+#' @param layer Table name for native DuckDB database output.
+#' @param storage_version Storage compatibility for newly created DuckDB
+#'   database output. The default, `"v1.5.0"`, preserves CRS natively but
+#'   requires DuckDB >= 1.5.0 to open the file. Use `"legacy"` to store CRS
+#'   metadata in duckspatial-managed column comments for older DuckDB readers.
 #' @param options Named list of additional options passed to `COPY`.
 #' @param partitioning Character vector of columns to partition by (Parquet/CSV only).
 #' @param parquet_compression Compression codec for Parquet.
@@ -90,6 +97,8 @@ ddbs_write_dataset <- function(
     conn = NULL,
     overwrite = FALSE,
     crs = NULL,
+    layer = "spatial",
+    storage_version = duckspatial_storage_default(),
     options = list(),
     partitioning = if (inherits(data, c("tbl_lazy", "duckspatial_df"))) dplyr::group_vars(data) else NULL,
     parquet_compression = NULL,
@@ -97,6 +106,7 @@ ddbs_write_dataset <- function(
     layer_creation_options = NULL,
     quiet = FALSE
 ) {
+  storage_version <- match.arg(storage_version, duckspatial_storage_versions())
   
   # 1. Resolve connection
   if (is.null(conn)) {
@@ -114,7 +124,8 @@ ddbs_write_dataset <- function(
   # Determine if native format
   is_parquet <- ext == "parquet"
   is_csv <- ext == "csv"
-  is_native <- is_parquet || is_csv
+  is_duckdb <- has_duckdb_file_extension(path)
+  is_native <- is_parquet || is_csv || is_duckdb
   
   # For GDAL formats, resolve driver
   driver_name <- NULL
@@ -194,8 +205,23 @@ ddbs_write_dataset <- function(
       if (!is_native) {
         unlink(path)
       }
+      if (is_duckdb) {
+        unlink(path)
+      }
       # For native (Parquet/CSV), we can use OVERWRITE_OR_IGNORE option below
     }
+  }
+
+  if (is_duckdb) {
+    return(ddbs_write_duckdb_dataset(
+      data = data,
+      path = path,
+      layer = layer,
+      overwrite = TRUE,
+      crs = crs,
+      storage_version = storage_version,
+      quiet = quiet
+    ))
   }
 
   # 4b. Auto-detect CRS if not provided
@@ -441,6 +467,44 @@ ddbs_write_dataset <- function(
       cli::cli_alert_success("Written to {.path {path}}")
   }
   
+  invisible(path)
+}
+
+#' Write a dataset to a native DuckDB database file
+#' @noRd
+ddbs_write_duckdb_dataset <- function(
+  data,
+  path,
+  layer,
+  overwrite,
+  crs,
+  storage_version,
+  quiet
+) {
+  target_conn <- ddbs_create_conn(path, storage_version = storage_version)
+  on.exit(ddbs_stop_conn(target_conn), add = TRUE)
+
+  if (!is.null(crs)) {
+    if (inherits(data, "sf")) {
+      sf::st_crs(data) <- sf::st_crs(crs)
+    } else if (inherits(data, c("duckspatial_df", "tbl_lazy", "tbl_duckdb_connection"))) {
+      data <- as_duckspatial_df(data, crs = crs)
+    }
+  }
+
+  ddbs_write_table(
+    conn = target_conn,
+    data = data,
+    name = layer,
+    overwrite = overwrite,
+    quiet = TRUE
+  )
+  ddbs_checkpoint_if_possible(target_conn)
+
+  if (!quiet) {
+    cli::cli_alert_success("Written to {.path {path}}")
+  }
+
   invisible(path)
 }
 

--- a/R/utils_format.R
+++ b/R/utils_format.R
@@ -19,6 +19,9 @@ get_file_format <- function(path) {
   if (ext %in% c("parquet")) {
     return("parquet")
   }
+  if (ext %in% c("duckdb", "db", "ddb")) {
+    return("duckdb")
+  }
   if (ext == "shp") {
      return("shp")
   }
@@ -41,6 +44,50 @@ get_file_format <- function(path) {
   
   # Return the extension purely for information/fallback usage
   return(ext)
+}
+
+duckdb_file_extensions <- function() {
+  c("duckdb", "db", "ddb")
+}
+
+has_duckdb_file_extension <- function(path) {
+  if (!is.character(path) || length(path) != 1) {
+    return(FALSE)
+  }
+  tolower(tools::file_ext(path)) %in% duckdb_file_extensions()
+}
+
+duckdb_file_info <- function(path) {
+  result <- list(
+    exists = FALSE,
+    size = NA_real_,
+    valid = FALSE,
+    empty = FALSE
+  )
+
+  if (!is.character(path) || length(path) != 1 || grepl("^[[:alpha:]][[:alnum:].+-]*://", path)) {
+    return(result)
+  }
+
+  if (!file.exists(path)) {
+    return(result)
+  }
+
+  info <- file.info(path)
+  result$exists <- TRUE
+  result$size <- info$size
+  result$empty <- isTRUE(result$size == 0)
+
+  if (is.na(result$size) || isTRUE(info$isdir) || result$size < 12) {
+    return(result)
+  }
+
+  con <- file(path, "rb")
+  on.exit(close(con), add = TRUE)
+  bytes <- readBin(con, "raw", n = 12)
+
+  result$valid <- length(bytes) >= 12 && identical(bytes[9:12], charToRaw("DUCK"))
+  result
 }
 
 #' Get CRS from Parquet metadata

--- a/R/utils_not_exported.R
+++ b/R/utils_not_exported.R
@@ -915,6 +915,21 @@ ddbs_temp_view_name <- function() { # nocov start
   paste0("temp_view_", gsub("-", "_", uuid::UUIDgenerate()))
 } # nocov end
 
+ddbs_checkpoint_if_possible <- function(conn) {
+  if (!DBI::dbIsValid(conn)) {
+    return(invisible(FALSE))
+  }
+
+  ok <- tryCatch({
+    DBI::dbExecute(conn, "FORCE CHECKPOINT")
+    TRUE
+  }, error = function(e) {
+    FALSE
+  })
+
+  invisible(ok)
+}
+
 #' Create an ephemeral DuckDB connection
 #'
 #' Creates a DuckDB connection that is automatically closed when the calling
@@ -958,7 +973,12 @@ ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE,
     if (isTRUE(read_only) && !file.exists(db_file)) {
       # Create the database file first in writable mode
       conn_init <- DBI::dbConnect(duckdb::duckdb(), dbdir = db_file, read_only = FALSE)
+      ddbs_checkpoint_if_possible(conn_init)
+      drv_init <- conn_init@driver
       DBI::dbDisconnect(conn_init)
+      if (inherits(drv_init, "duckdb_driver")) {
+        duckdb::duckdb_shutdown(drv_init)
+      }
     }
     
     conn <- DBI::dbConnect(duckdb::duckdb(), dbdir = db_file, read_only = read_only)
@@ -978,6 +998,9 @@ ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE,
     # Cleanup: disconnect and optionally delete file
     withr::defer({
       if (DBI::dbIsValid(conn)) {
+        if (!isTRUE(read_only)) {
+          ddbs_checkpoint_if_possible(conn)
+        }
         drv <- conn@driver
         tryCatch(suppressWarnings(DBI::dbDisconnect(conn)), error = function(e) NULL)
         if (inherits(drv, "duckdb_driver")) {

--- a/R/utils_not_exported.R
+++ b/R/utils_not_exported.R
@@ -978,7 +978,11 @@ ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE,
     # Cleanup: disconnect and optionally delete file
     withr::defer({
       if (DBI::dbIsValid(conn)) {
-        tryCatch(suppressWarnings(DBI::dbDisconnect(conn, shutdown = TRUE)), error = function(e) NULL)
+        drv <- conn@driver
+        tryCatch(suppressWarnings(DBI::dbDisconnect(conn)), error = function(e) NULL)
+        if (inherits(drv, "duckdb_driver")) {
+          tryCatch(duckdb::duckdb_shutdown(drv), error = function(e) NULL)
+        }
       }
       if (isTRUE(cleanup) && file.exists(db_file)) unlink(db_file)
     }, envir = envir)
@@ -987,7 +991,11 @@ ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE,
     conn <- ddbs_create_conn(dbdir = "memory", threads = threads, memory_limit_gb = memory_limit_gb)
     withr::defer({
       if (DBI::dbIsValid(conn)) {
+        drv <- conn@driver
         tryCatch(suppressWarnings(DBI::dbDisconnect(conn)), error = function(e) NULL)
+        if (inherits(drv, "duckdb_driver")) {
+          tryCatch(duckdb::duckdb_shutdown(drv), error = function(e) NULL)
+        }
       }
     }, envir = envir)
   }

--- a/R/utils_not_exported.R
+++ b/R/utils_not_exported.R
@@ -930,8 +930,17 @@ ddbs_checkpoint_if_possible <- function(conn) {
 #'   parent frame (the caller's environment).
 #' @template threads
 #' @template memory_limit_gb
-#' @param storage_version Storage compatibility for newly created persistent
-#'   DuckDB files. See \code{\link{ddbs_create_conn}}.
+#' @param duckdb_storage_version Storage compatibility for newly created persistent
+#'   native DuckDB files (\code{.duckdb}, \code{.db}, \code{.ddb}).
+#'   \itemize{
+#'     \item \code{"v1.5.0"} (\strong{Native Spatial Storage}, Default): Preserves
+#'           CRS metadata in native DuckDB \code{GEOMETRY} columns. Requires
+#'           DuckDB >= 1.5.0 to open the file.
+#'     \item \code{"v1.0.0"} (\strong{Legacy Compatibility}): Creates
+#'           files readable by older DuckDB versions (>= 1.0.0). Persists CRS
+#'           metadata in duckspatial-managed column comments (a convention not
+#'           recognized by other spatial software).
+#'   }
 #'
 #' @returns A `duckdb_connection` that will be automatically closed on exit.
 #'   For file-based connections, also returns the file path as an attribute 
@@ -940,11 +949,11 @@ ddbs_checkpoint_if_possible <- function(conn) {
 #' @keywords internal
 ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE, 
                             envir = parent.frame(), threads = NULL, memory_limit_gb = NULL,
-                            storage_version = duckspatial_storage_default()) {
+                            duckdb_storage_version = duckspatial_storage_default()) {
 
   assert_threads(threads)
   assert_memory_limit_gb(memory_limit_gb)
-  storage_version <- match.arg(storage_version, duckspatial_storage_versions())
+  duckdb_storage_version <- match_duckdb_storage_version(duckdb_storage_version)
 
   if (isTRUE(file) || is.character(file)) {
     # File-based connection
@@ -960,7 +969,7 @@ ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE,
       # Create the database file first in writable mode
       conn_init <- ddbs_open_persistent(
         db_file,
-        storage_version = storage_version,
+        duckdb_storage_version = duckdb_storage_version,
         read_only = FALSE
       )
       ddbs_checkpoint_if_possible(conn_init)
@@ -973,7 +982,7 @@ ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE,
     
     conn <- ddbs_open_persistent(
       db_file,
-      storage_version = storage_version,
+      duckdb_storage_version = duckdb_storage_version,
       read_only = read_only
     )
     
@@ -1008,7 +1017,7 @@ ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE,
       dbdir = "memory",
       threads = threads,
       memory_limit_gb = memory_limit_gb,
-      storage_version = storage_version
+      duckdb_storage_version = duckdb_storage_version
     )
     withr::defer({
       if (DBI::dbIsValid(conn)) {

--- a/R/utils_not_exported.R
+++ b/R/utils_not_exported.R
@@ -108,26 +108,8 @@ get_conn_from_input <- function(x) {  # nocov start
 #' @return Logical indicating if CRS are equal
 #' @keywords internal
 crs_equal <- function(crs1, crs2) {  # nocov start
-  # If either is NULL, skip check
-  if (is.null(crs1) || is.null(crs2)) return(TRUE)
-  
-  # Normalize to sf crs objects
-  crs1 <- sf::st_crs(crs1)
-  crs2 <- sf::st_crs(crs2)
-  
-  # If both are NA, they're equal
-  if (is.na(crs1) && is.na(crs2)) return(TRUE)
-  
-  # If one is NA and other isn't, they're different
-  if (is.na(crs1) || is.na(crs2)) return(FALSE)
-  
-  # Compare EPSG codes if both have them
-  if (!is.na(crs1$epsg) && !is.na(crs2$epsg)) {
-    return(crs1$epsg == crs2$epsg)
-  }
-  
-  # Fallback to WKT comparison
-  identical(crs1$wkt, crs2$wkt)
+  if (is.null(crs1) || is.null(crs2)) return(FALSE)
+  isTRUE(sf::st_crs(crs1) == sf::st_crs(crs2))
 }  # nocov end
 
 #' Import a view/table from one connection to another
@@ -948,6 +930,8 @@ ddbs_checkpoint_if_possible <- function(conn) {
 #'   parent frame (the caller's environment).
 #' @template threads
 #' @template memory_limit_gb
+#' @param storage_version Storage compatibility for newly created persistent
+#'   DuckDB files. See \code{\link{ddbs_create_conn}}.
 #'
 #' @returns A `duckdb_connection` that will be automatically closed on exit.
 #'   For file-based connections, also returns the file path as an attribute 
@@ -955,10 +939,12 @@ ddbs_checkpoint_if_possible <- function(conn) {
 #' @noRd
 #' @keywords internal
 ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE, 
-                            envir = parent.frame(), threads = NULL, memory_limit_gb = NULL) {
+                            envir = parent.frame(), threads = NULL, memory_limit_gb = NULL,
+                            storage_version = duckspatial_storage_default()) {
 
   assert_threads(threads)
   assert_memory_limit_gb(memory_limit_gb)
+  storage_version <- match.arg(storage_version, duckspatial_storage_versions())
 
   if (isTRUE(file) || is.character(file)) {
     # File-based connection
@@ -972,7 +958,11 @@ ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE,
     # If creating a new tempfile with read_only=TRUE, we must create it first
     if (isTRUE(read_only) && !file.exists(db_file)) {
       # Create the database file first in writable mode
-      conn_init <- DBI::dbConnect(duckdb::duckdb(), dbdir = db_file, read_only = FALSE)
+      conn_init <- ddbs_open_persistent(
+        db_file,
+        storage_version = storage_version,
+        read_only = FALSE
+      )
       ddbs_checkpoint_if_possible(conn_init)
       drv_init <- conn_init@driver
       DBI::dbDisconnect(conn_init)
@@ -981,8 +971,11 @@ ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE,
       }
     }
     
-    conn <- DBI::dbConnect(duckdb::duckdb(), dbdir = db_file, read_only = read_only)
-    attr(conn, "db_file") <- db_file
+    conn <- ddbs_open_persistent(
+      db_file,
+      storage_version = storage_version,
+      read_only = read_only
+    )
     
     # Checks and installs the Spatial extension
     # NOTE: These operations work fine on read-only connections:
@@ -1011,7 +1004,12 @@ ddbs_temp_conn <- function(file = FALSE, read_only = FALSE, cleanup = TRUE,
     }, envir = envir)
   } else {
     # In-memory connection
-    conn <- ddbs_create_conn(dbdir = "memory", threads = threads, memory_limit_gb = memory_limit_gb)
+    conn <- ddbs_create_conn(
+      dbdir = "memory",
+      threads = threads,
+      memory_limit_gb = memory_limit_gb,
+      storage_version = storage_version
+    )
     withr::defer({
       if (DBI::dbIsValid(conn)) {
         drv <- conn@driver
@@ -1180,13 +1178,7 @@ build_geom_query <- function(fun, name, crs, mode) { # nocov start
   } else {
     ## When creating a table in a connection, we preserve the CRS
     ## in the geometry column
-    ## Get the CRS, and define the geometry type for duckdb    
-    data_crs   <- sf::st_crs(crs, parameters = TRUE)
-    if (length(data_crs) == 0 | is.na(data_crs$srid)) {
-        geom_field <- glue::glue("GEOMETRY")
-    } else {
-        geom_field <- glue::glue("GEOMETRY('{data_crs$srid}')")
-    }
+    geom_field <- duckdb_geometry_type(conn = NULL, crs)
     glue::glue("{fun}::{geom_field}")
   }
 } # nocov end
@@ -1334,15 +1326,8 @@ get_table_crs <- function(conn, geom_name, table_name) { # nocov start
 #'
 #' @keywords internal
 #' @noRd
-get_geometry_type_duckdb <- function(x) { # nocov start
-  data_crs <- sf::st_crs(x, parameters = TRUE)
-  # st_crs returns a list where srid is NA if not found
-  if (length(data_crs) == 0 || is.na(data_crs$srid)) {
-    geom_field <- "GEOMETRY"
-  } else {
-    geom_field <- glue::glue("GEOMETRY('{data_crs$srid}')")
-  }
-  return(geom_field)
+get_geometry_type_duckdb <- function(x, conn = NULL) { # nocov start
+  duckdb_geometry_type(conn, x)
 } # nocov end
 
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -5,7 +5,8 @@
   op <- options()
   op_duckspatial <- list(
     duckspatial.output_type = "duckspatial_df",
-    duckspatial.max_rows = 1e6
+    duckspatial.max_rows = 1e6,
+    duckspatial.duckdb_storage_version = "v1.5.0"
   )
   toset <- !(names(op_duckspatial) %in% names(op))
   if (any(toset)) options(op_duckspatial[toset])

--- a/man/as_duckspatial_df.Rd
+++ b/man/as_duckspatial_df.Rd
@@ -29,8 +29,8 @@ as_duckspatial_df(x, conn = NULL, crs = NULL, geom_col = NULL, ...)
 
 \item{conn}{DuckDB connection (required for character table names)}
 
-\item{crs}{CRS object or string (auto-detected from sf objects, but must be
-provided manually when reopening persistent DuckDB tables)}
+\item{crs}{CRS object or string. Auto-detected from \code{sf} objects and
+persistent DuckDB tables.}
 
 \item{geom_col}{Geometry column name (default: "geom")}
 
@@ -52,5 +52,9 @@ table (\code{tbl_duckdb_connection}), the function creates a zero-copy represent
 of the data directly from the database without loading it into memory. This is
 the canonical way to "register" or wrap existing persistent spatial tables.
 
-\strong{CRS Persistence:} `duckspatial`` reads native DuckDB 1.5 CRS metadata and, for compatibility files written by duckspatial, CRS metadata stored in duckspatial-managed column comments. DuckDB files saved in pre-1.5 format without duckspatial-managed comments will not have CRS information and will default to NA with a warning. To ensure CRS persistence, use DuckDB 1.5+ and  when creating DuckDB database files.
+\strong{CRS Persistence:} \code{duckspatial} reads native DuckDB 1.5.0+ CRS metadata
+and, for compatibility with files written by older versions of \code{duckspatial},
+CRS metadata stored in column comments. DuckDB files saved in pre-1.5.0
+format without \code{duckspatial}-managed comments will not have CRS information
+and will default to \code{NA} with a warning.
 }

--- a/man/as_duckspatial_df.Rd
+++ b/man/as_duckspatial_df.Rd
@@ -29,7 +29,8 @@ as_duckspatial_df(x, conn = NULL, crs = NULL, geom_col = NULL, ...)
 
 \item{conn}{DuckDB connection (required for character table names)}
 
-\item{crs}{CRS object or string (auto-detected from sf objects)}
+\item{crs}{CRS object or string (auto-detected from sf objects, but must be
+provided manually when reopening persistent DuckDB tables)}
 
 \item{geom_col}{Geometry column name (default: "geom")}
 
@@ -45,5 +46,15 @@ as_duckspatial_df(x, conn = NULL, crs = NULL, geom_col = NULL, ...)
 A duckspatial_df object
 }
 \description{
-Convert objects to duckspatial_df
+\code{as_duckspatial_df()} creates a lazy spatial data frame (\code{duckspatial_df}) from
+various inputs. When \code{x} is a table name (character) or an existing DuckDB
+table (\code{tbl_duckdb_connection}), the function creates a zero-copy representation
+of the data directly from the database without loading it into memory. This is
+the canonical way to "register" or wrap existing persistent spatial tables.
+
+\strong{Important Note on CRS Persistence:} Due to an upstream limitation in DuckDB
+(as of v1.5), CRS metadata is not reliably persisted when a database is closed
+and reopened. When reopening a persistent \code{.duckdb} database, \code{as_duckspatial_df()}
+may not be able to auto-detect the CRS, and you will need to provide it manually
+via the \code{crs} argument.
 }

--- a/man/as_duckspatial_df.Rd
+++ b/man/as_duckspatial_df.Rd
@@ -52,9 +52,5 @@ table (\code{tbl_duckdb_connection}), the function creates a zero-copy represent
 of the data directly from the database without loading it into memory. This is
 the canonical way to "register" or wrap existing persistent spatial tables.
 
-\strong{Important Note on CRS Persistence:} Due to an upstream limitation in DuckDB
-(as of v1.5), CRS metadata is not reliably persisted when a database is closed
-and reopened. When reopening a persistent \code{.duckdb} database, \code{as_duckspatial_df()}
-may not be able to auto-detect the CRS, and you will need to provide it manually
-via the \code{crs} argument.
+\strong{CRS Persistence:} `duckspatial`` reads native DuckDB 1.5 CRS metadata and, for compatibility files written by duckspatial, CRS metadata stored in duckspatial-managed column comments. DuckDB files saved in pre-1.5 format without duckspatial-managed comments will not have CRS information and will default to NA with a warning. To ensure CRS persistence, use DuckDB 1.5+ and  when creating DuckDB database files.
 }

--- a/man/ddbs_create_conn.Rd
+++ b/man/ddbs_create_conn.Rd
@@ -13,8 +13,8 @@ ddbs_create_conn(
 )
 }
 \arguments{
-\item{dbdir}{String. Either \code{"tempdir"}, \code{"memory"}, or file path with
-\code{.duckdb} or \code{.db} extension. Defaults to \code{"memory"}.}
+\item{dbdir}{String. Either \code{"tempdir"}, \code{"memory"}, or a DuckDB database
+file path with \code{.duckdb}, \code{.db}, or \code{.ddb} extension. Defaults to \code{"memory"}.}
 
 \item{threads}{Integer. Number of threads to use. If \code{NULL} (default), the setting is not changed, and DuckDB engine will use all available cores it detects (warning, on some shared HPC nodes the detected number of cores might be total number of cores on the node, not the per-job allocation).}
 

--- a/man/ddbs_create_conn.Rd
+++ b/man/ddbs_create_conn.Rd
@@ -9,8 +9,8 @@ ddbs_create_conn(
   threads = NULL,
   memory_limit_gb = NULL,
   upgrade = FALSE,
-  storage_version = duckspatial_storage_default(),
-  ...
+  ...,
+  duckdb_storage_version = duckspatial_storage_default()
 )
 }
 \arguments{
@@ -23,15 +23,24 @@ file path with \code{.duckdb}, \code{.db}, or \code{.ddb} extension. Defaults to
 
 \item{upgrade}{if TRUE, it upgrades the DuckDB extension to the latest version}
 
-\item{storage_version}{Storage compatibility for newly created persistent
-DuckDB files. The default, \code{"v1.5.0"} (\strong{Native Persistence}), preserves
-CRS metadata in native DuckDB \code{GEOMETRY} columns but requires
-DuckDB >= 1.5.0 to open the file. Use \code{"legacy"} (\strong{Metadata Fallback})
-to create files readable by older DuckDB versions and persist CRS
-metadata in duckspatial-managed column comments (note that these comments
-are a duckspatial convention and not recognized by other spatial software).}
-
 \item{...}{Additional parameters to be passed to \code{\link[DBI]{dbConnect}}}
+
+\item{duckdb_storage_version}{Storage compatibility for newly created persistent
+native DuckDB files (\code{.duckdb}, \code{.db}, \code{.ddb}). See
+\url{https://duckdb.org/docs/internals/storage} for more information on
+DuckDB storage versions and compatibility.
+\itemize{
+\item \code{"v1.5.0"} (\strong{Native Spatial Storage}, Default): Preserves
+CRS metadata in native DuckDB \code{GEOMETRY} columns. Requires
+DuckDB >= 1.5.0 to open the file.
+\item \code{"v1.0.0"} (\strong{Legacy Compatibility}): Creates
+files readable by older DuckDB versions (>= 1.0.0). Persists CRS
+metadata in duckspatial-managed column comments (a convention not
+recognized by other spatial software).
+\item \code{"latest"}: Use the highest storage version supported by your
+installed DuckDB engine.
+}
+Other major version strings like \code{"v1.4.0"}, \code{"v1.3.0"}, etc., are also supported.}
 }
 \value{
 A \code{duckdb_connection}

--- a/man/ddbs_create_conn.Rd
+++ b/man/ddbs_create_conn.Rd
@@ -24,10 +24,12 @@ file path with \code{.duckdb}, \code{.db}, or \code{.ddb} extension. Defaults to
 \item{upgrade}{if TRUE, it upgrades the DuckDB extension to the latest version}
 
 \item{storage_version}{Storage compatibility for newly created persistent
-DuckDB files. The default, \code{"v1.5.0"}, preserves CRS metadata in native
-DuckDB \code{GEOMETRY} columns but requires DuckDB >= 1.5.0 to open the file.
-Use \code{"legacy"} to create files readable by older DuckDB versions and
-persist CRS metadata in duckspatial-managed column comments.}
+DuckDB files. The default, \code{"v1.5.0"} (\strong{Native Persistence}), preserves
+CRS metadata in native DuckDB \code{GEOMETRY} columns but requires
+DuckDB >= 1.5.0 to open the file. Use \code{"legacy"} (\strong{Metadata Fallback})
+to create files readable by older DuckDB versions and persist CRS
+metadata in duckspatial-managed column comments (note that these comments
+are a duckspatial convention and not recognized by other spatial software).}
 
 \item{...}{Additional parameters to be passed to \code{\link[DBI]{dbConnect}}}
 }

--- a/man/ddbs_create_conn.Rd
+++ b/man/ddbs_create_conn.Rd
@@ -9,6 +9,7 @@ ddbs_create_conn(
   threads = NULL,
   memory_limit_gb = NULL,
   upgrade = FALSE,
+  storage_version = duckspatial_storage_default(),
   ...
 )
 }
@@ -21,6 +22,12 @@ file path with \code{.duckdb}, \code{.db}, or \code{.ddb} extension. Defaults to
 \item{memory_limit_gb}{Numeric. Memory limit in GB. If \code{NULL} (default), the setting is not changed, and DuckDB engine will use 80\% of available operating system memory it detects (warning, on some shared HPC nodes the detected memory might be the full node memory, not the per-job allocation).}
 
 \item{upgrade}{if TRUE, it upgrades the DuckDB extension to the latest version}
+
+\item{storage_version}{Storage compatibility for newly created persistent
+DuckDB files. The default, \code{"v1.5.0"}, preserves CRS metadata in native
+DuckDB \code{GEOMETRY} columns but requires DuckDB >= 1.5.0 to open the file.
+Use \code{"legacy"} to create files readable by older DuckDB versions and
+persist CRS metadata in duckspatial-managed column comments.}
 
 \item{...}{Additional parameters to be passed to \code{\link[DBI]{dbConnect}}}
 }

--- a/man/ddbs_open_dataset.Rd
+++ b/man/ddbs_open_dataset.Rd
@@ -36,7 +36,10 @@ GeoJSON, GeoPackage, Shapefile, FlatGeoBuf, OSM PBF, DuckDB database files
 
 \item{crs}{Coordinate reference system. Can be an EPSG code (e.g., 4326),
 a CRS string, or an \code{sf} crs object. If \code{NULL} (default),
-attempts to auto-detect from the file.}
+attempts to auto-detect from the file. \strong{Important:} Due to an upstream
+limitation in DuckDB (as of v1.5), CRS metadata is not reliably persisted
+in \code{.duckdb} files. When opening tables from persistent DuckDB files, you
+must provide this argument manually.}
 
 \item{layer}{Layer name or index to read (ST_Read). For DuckDB database
 files, this is required and specifies the table name to read. Default is

--- a/man/ddbs_open_dataset.Rd
+++ b/man/ddbs_open_dataset.Rd
@@ -36,10 +36,9 @@ GeoJSON, GeoPackage, Shapefile, FlatGeoBuf, OSM PBF, DuckDB database files
 
 \item{crs}{Coordinate reference system. Can be an EPSG code (e.g., 4326),
 a CRS string, or an \code{sf} crs object. If \code{NULL} (default),
-attempts to auto-detect from the file. \strong{Important:} Due to an upstream
-limitation in DuckDB (as of v1.5), CRS metadata is not reliably persisted
-in \code{.duckdb} files. When opening tables from persistent DuckDB files, you
-must provide this argument manually.}
+attempts to auto-detect from the file, including native DuckDB CRS metadata
+and duckspatial-managed column-comment metadata for compatibility
+\code{.duckdb} files.}
 
 \item{layer}{Layer name or index to read (ST_Read). For DuckDB database
 files, this is required and specifies the table name to read. Default is

--- a/man/ddbs_open_dataset.Rd
+++ b/man/ddbs_open_dataset.Rd
@@ -31,13 +31,16 @@ ddbs_open_dataset(
 }
 \arguments{
 \item{path}{Path to spatial file. Supports Parquet (\code{.parquet}, with optional GeoParquet metadata),
-GeoJSON, GeoPackage, Shapefile, FlatGeoBuf, OSM PBF, and other GDAL-supported formats.}
+GeoJSON, GeoPackage, Shapefile, FlatGeoBuf, OSM PBF, DuckDB database files
+(\code{.duckdb}, \code{.db}, and \code{.ddb}), and other GDAL-supported formats.}
 
 \item{crs}{Coordinate reference system. Can be an EPSG code (e.g., 4326),
 a CRS string, or an \code{sf} crs object. If \code{NULL} (default),
 attempts to auto-detect from the file.}
 
-\item{layer}{Layer name or index to read (ST_Read only). Default is NULL (first layer).}
+\item{layer}{Layer name or index to read (ST_Read). For DuckDB database
+files, this is required and specifies the table name to read. Default is
+NULL (first layer for ST_Read).}
 
 \item{geom_col}{Name of the geometry column. Default is \code{NULL}, which attempts
 auto-detection.}

--- a/man/ddbs_options.Rd
+++ b/man/ddbs_options.Rd
@@ -4,7 +4,7 @@
 \alias{ddbs_options}
 \title{Get or set global duckspatial options}
 \usage{
-ddbs_options(output_type = NULL, mode = NULL)
+ddbs_options(output_type = NULL, mode = NULL, duckdb_storage_version = NULL)
 }
 \arguments{
 \item{output_type}{Character string. Controls the default return type for \link{ddbs_collect}.
@@ -23,6 +23,10 @@ If \code{NULL} (the default), the existing option is not changed.}
 \item \code{"sf"}: Eagerly collected sf object (uses memory)
 }
 If \code{NULL} (the default), the existing option is not changed.}
+
+\item{duckdb_storage_version}{Character. The default DuckDB storage compatibility version
+for newly created database files. See \url{https://duckdb.org/docs/internals/storage}
+for details.}
 }
 \value{
 Invisibly returns a list containing the currently set options.

--- a/man/ddbs_write_dataset.Rd
+++ b/man/ddbs_write_dataset.Rd
@@ -62,9 +62,12 @@ runs on a temporary DuckDB database.}
 \item{layer}{Table name for native DuckDB database output.}
 
 \item{storage_version}{Storage compatibility for newly created DuckDB
-database output. The default, \code{"v1.5.0"}, preserves CRS natively but
-requires DuckDB >= 1.5.0 to open the file. Use \code{"legacy"} to store CRS
-metadata in duckspatial-managed column comments for older DuckDB readers.}
+database output. The default, \code{"v1.5.0"} (\strong{Native Persistence}),
+preserves CRS natively but requires DuckDB >= 1.5.0 to open the file.
+Use \code{"legacy"} (\strong{Metadata Fallback}) to store CRS metadata in
+duckspatial-managed column comments for older DuckDB readers (note that
+these comments are a duckspatial convention and not recognized by other
+spatial software).}
 
 \item{options}{Named list of additional options passed to \code{COPY}.}
 
@@ -89,11 +92,11 @@ and \code{.ddb} paths. Format is auto-detected from file extension for common
 formats, or can be specified explicitly via \code{gdal_driver}.
 }
 \details{
-Persistent DuckDB database files created by duckspatial use DuckDB storage
-compatibility version \code{"v1.5.0"} by default so CRS metadata is retained in
-native \code{GEOMETRY} columns. These files require DuckDB >= 1.5.0 to open; use
-\code{storage_version = "legacy"} when the output must be readable by older
-DuckDB versions.
+Persistent DuckDB database files created by duckspatial use \strong{Native
+Persistence} (\code{storage_version = "v1.5.0"}) by default so CRS metadata is
+retained in native \code{GEOMETRY} columns. These files require DuckDB >= 1.5.0
+to open; use \strong{Metadata Fallback} (\code{storage_version = "legacy"}) when the
+output must be readable by older DuckDB versions.
 }
 \examples{
 \dontrun{

--- a/man/ddbs_write_dataset.Rd
+++ b/man/ddbs_write_dataset.Rd
@@ -78,6 +78,12 @@ Writes spatial data to disk using DuckDB's \code{COPY} command. Supports Parquet
 and various GDAL spatial formats. Format is auto-detected from file extension for
 common formats, or can be specified explicitly via \code{gdal_driver}.
 }
+\details{
+\strong{Recommendation:} If you need to persistently save spatial data and reliably retain
+Coordinate Reference System (CRS) metadata across sessions, \strong{GeoParquet (\code{.parquet})
+is the recommended format.} DuckDB's native \code{.duckdb} database format currently
+drops CRS metadata upon closing.
+}
 \examples{
 \dontrun{
 library(duckspatial)

--- a/man/ddbs_write_dataset.Rd
+++ b/man/ddbs_write_dataset.Rd
@@ -11,6 +11,8 @@ ddbs_write_dataset(
   conn = NULL,
   overwrite = FALSE,
   crs = NULL,
+  layer = "spatial",
+  storage_version = duckspatial_storage_default(),
   options = list(),
   partitioning = if (inherits(data, c("tbl_lazy", "duckspatial_df")))
     dplyr::group_vars(data) else NULL,
@@ -57,6 +59,13 @@ runs on a temporary DuckDB database.}
 
 \item{crs}{Output CRS (e.g., "EPSG:4326"). Passed to GDAL as \code{SRS} option. Ignored for Parquet.}
 
+\item{layer}{Table name for native DuckDB database output.}
+
+\item{storage_version}{Storage compatibility for newly created DuckDB
+database output. The default, \code{"v1.5.0"}, preserves CRS natively but
+requires DuckDB >= 1.5.0 to open the file. Use \code{"legacy"} to store CRS
+metadata in duckspatial-managed column comments for older DuckDB readers.}
+
 \item{options}{Named list of additional options passed to \code{COPY}.}
 
 \item{partitioning}{Character vector of columns to partition by (Parquet/CSV only).}
@@ -74,15 +83,17 @@ Defaults to \code{FALSE}.}
 The \code{path} invisibly.
 }
 \description{
-Writes spatial data to disk using DuckDB's \code{COPY} command. Supports Parquet (native)
-and various GDAL spatial formats. Format is auto-detected from file extension for
-common formats, or can be specified explicitly via \code{gdal_driver}.
+Writes spatial data to disk using DuckDB's \code{COPY} command for Parquet and
+GDAL spatial formats, or as a native DuckDB database for \code{.duckdb}, \code{.db},
+and \code{.ddb} paths. Format is auto-detected from file extension for common
+formats, or can be specified explicitly via \code{gdal_driver}.
 }
 \details{
-\strong{Recommendation:} If you need to persistently save spatial data and reliably retain
-Coordinate Reference System (CRS) metadata across sessions, \strong{GeoParquet (\code{.parquet})
-is the recommended format.} DuckDB's native \code{.duckdb} database format currently
-drops CRS metadata upon closing.
+Persistent DuckDB database files created by duckspatial use DuckDB storage
+compatibility version \code{"v1.5.0"} by default so CRS metadata is retained in
+native \code{GEOMETRY} columns. These files require DuckDB >= 1.5.0 to open; use
+\code{storage_version = "legacy"} when the output must be readable by older
+DuckDB versions.
 }
 \examples{
 \dontrun{

--- a/man/ddbs_write_dataset.Rd
+++ b/man/ddbs_write_dataset.Rd
@@ -12,14 +12,14 @@ ddbs_write_dataset(
   overwrite = FALSE,
   crs = NULL,
   layer = "spatial",
-  storage_version = duckspatial_storage_default(),
   options = list(),
   partitioning = if (inherits(data, c("tbl_lazy", "duckspatial_df")))
     dplyr::group_vars(data) else NULL,
   parquet_compression = NULL,
   parquet_row_group_size = NULL,
   layer_creation_options = NULL,
-  quiet = FALSE
+  quiet = FALSE,
+  duckdb_storage_version = duckspatial_storage_default()
 )
 }
 \arguments{
@@ -61,14 +61,6 @@ runs on a temporary DuckDB database.}
 
 \item{layer}{Table name for native DuckDB database output.}
 
-\item{storage_version}{Storage compatibility for newly created DuckDB
-database output. The default, \code{"v1.5.0"} (\strong{Native Persistence}),
-preserves CRS natively but requires DuckDB >= 1.5.0 to open the file.
-Use \code{"legacy"} (\strong{Metadata Fallback}) to store CRS metadata in
-duckspatial-managed column comments for older DuckDB readers (note that
-these comments are a duckspatial convention and not recognized by other
-spatial software).}
-
 \item{options}{Named list of additional options passed to \code{COPY}.}
 
 \item{partitioning}{Character vector of columns to partition by (Parquet/CSV only).}
@@ -81,6 +73,23 @@ spatial software).}
 
 \item{quiet}{A logical value. If \code{TRUE}, suppresses any informational messages.
 Defaults to \code{FALSE}.}
+
+\item{duckdb_storage_version}{Storage compatibility for newly created native
+DuckDB database files (\code{.duckdb}, \code{.db}, \code{.ddb}). See
+\url{https://duckdb.org/docs/internals/storage} for more information on
+DuckDB storage versions and compatibility.
+\itemize{
+\item \code{"v1.5.0"} (\strong{Native Spatial Storage}, Default): Preserves
+CRS metadata in native DuckDB \code{GEOMETRY} columns. Requires
+DuckDB >= 1.5.0 to open the file.
+\item \code{"v1.0.0"} (\strong{Legacy Compatibility}): Creates
+files readable by older DuckDB versions (>= 1.0.0). Persists CRS
+metadata in duckspatial-managed column comments (a convention not
+recognized by other spatial software).
+\item \code{"latest"}: Use the highest storage version supported by your
+installed DuckDB engine.
+}
+Other major version strings like \code{"v1.4.0"}, \code{"v1.3.0"}, etc., are also supported.}
 }
 \value{
 The \code{path} invisibly.
@@ -93,10 +102,10 @@ formats, or can be specified explicitly via \code{gdal_driver}.
 }
 \details{
 Persistent DuckDB database files created by duckspatial use \strong{Native
-Persistence} (\code{storage_version = "v1.5.0"}) by default so CRS metadata is
+Spatial Storage} (\code{storage_version = "v1.5.0"}) by default so CRS metadata is
 retained in native \code{GEOMETRY} columns. These files require DuckDB >= 1.5.0
-to open; use \strong{Metadata Fallback} (\code{storage_version = "legacy"}) when the
-output must be readable by older DuckDB versions.
+to open; use \strong{Legacy Compatibility} (\code{storage_version = "v1.0.0"})
+when the output must be readable by older DuckDB versions.
 }
 \examples{
 \dontrun{

--- a/man/ddbs_write_table.Rd
+++ b/man/ddbs_write_table.Rd
@@ -42,11 +42,11 @@ This function writes a Simple Features (SF) object into a DuckDB database as a n
 The table is created in the specified schema of the DuckDB database.
 }
 \details{
-\strong{Important Note on CRS Persistence:} Due to an upstream limitation in DuckDB
-(as of v1.5), CRS metadata is not reliably persisted when a \code{.duckdb} database
-is closed and reopened. If you need to persistently save spatial data and
-seamlessly retain CRS metadata across sessions, using \code{\link[=ddbs_write_dataset]{ddbs_write_dataset()}}
-to save to a GeoParquet (\code{.parquet}) file is strongly recommended.
+\strong{CRS Persistence:} \code{duckspatial} ensures CRS metadata is retained across
+sessions using two strategies: \strong{Native Persistence} (for DuckDB 1.5.0+
+databases) and \strong{Metadata Fallback} (using column comments for older
+database versions). For file-based spatial data interchange,
+\code{\link[=ddbs_write_dataset]{ddbs_write_dataset()}} to GeoParquet (\code{.parquet}) is recommended.
 }
 \examples{
 \dontrun{

--- a/man/ddbs_write_table.Rd
+++ b/man/ddbs_write_table.Rd
@@ -41,6 +41,13 @@ TRUE (invisibly) for successful import
 This function writes a Simple Features (SF) object into a DuckDB database as a new table.
 The table is created in the specified schema of the DuckDB database.
 }
+\details{
+\strong{Important Note on CRS Persistence:} Due to an upstream limitation in DuckDB
+(as of v1.5), CRS metadata is not reliably persisted when a \code{.duckdb} database
+is closed and reopened. If you need to persistently save spatial data and
+seamlessly retain CRS metadata across sessions, using \code{\link[=ddbs_write_dataset]{ddbs_write_dataset()}}
+to save to a GeoParquet (\code{.parquet}) file is strongly recommended.
+}
 \examples{
 \dontrun{
 ## load packages

--- a/man/ddbs_write_table.Rd
+++ b/man/ddbs_write_table.Rd
@@ -43,8 +43,8 @@ The table is created in the specified schema of the DuckDB database.
 }
 \details{
 \strong{CRS Persistence:} \code{duckspatial} ensures CRS metadata is retained across
-sessions using two strategies: \strong{Native Persistence} (for DuckDB 1.5.0+
-databases) and \strong{Metadata Fallback} (using column comments for older
+sessions using two strategies: \strong{Native Spatial Storage} (for DuckDB 1.5.0+
+databases) and \strong{Legacy Compatibility} (using column comments for older
 database versions). For file-based spatial data interchange,
 \code{\link[=ddbs_write_dataset]{ddbs_write_dataset()}} to GeoParquet (\code{.parquet}) is recommended.
 }

--- a/tests/testthat/test-connection-management.R
+++ b/tests/testthat/test-connection-management.R
@@ -3,6 +3,34 @@ testthat::skip_on_cran()
 
 # Tests for connection management
 
+test_that("ddbs_create_conn accepts only supported DuckDB file extensions", {
+  for (ext in c(".duckdb", ".db", ".ddb")) {
+    db_path <- tempfile(fileext = ext)
+    on.exit(unlink(db_path), add = TRUE)
+
+    conn <- ddbs_create_conn(db_path)
+    DBI::dbExecute(conn, "CREATE TABLE extension_check AS SELECT 1 AS value")
+    ddbs_stop_conn(conn)
+
+    conn <- ddbs_create_conn(db_path)
+    on.exit({
+      if (DBI::dbIsValid(conn)) {
+        ddbs_stop_conn(conn)
+      }
+    }, add = TRUE)
+    expect_equal(
+      DBI::dbGetQuery(conn, "SELECT value FROM extension_check")$value,
+      1
+    )
+    ddbs_stop_conn(conn)
+  }
+
+  expect_error(
+    ddbs_create_conn(tempfile(fileext = ".txt")),
+    "duckdb.*db.*ddb"
+  )
+})
+
 test_that("cross-connection filtering works with proper fallback strategies", {
   skip_if_not_installed("sf")
 

--- a/tests/testthat/test-connection-management.R
+++ b/tests/testthat/test-connection-management.R
@@ -8,21 +8,20 @@ test_that("ddbs_create_conn accepts only supported DuckDB file extensions", {
     db_path <- tempfile(fileext = ext)
     on.exit(unlink(db_path), add = TRUE)
 
-    conn <- ddbs_create_conn(db_path)
-    DBI::dbExecute(conn, "CREATE TABLE extension_check AS SELECT 1 AS value")
-    ddbs_stop_conn(conn)
+    # 1. Create and write (using explicit cleanup = FALSE to keep file for step 2)
+    local({
+      conn <- ddbs_temp_conn(file = db_path, cleanup = FALSE)
+      DBI::dbExecute(conn, "CREATE TABLE extension_check AS SELECT 1 AS value")
+    })
 
-    conn <- ddbs_create_conn(db_path)
-    on.exit({
-      if (DBI::dbIsValid(conn)) {
-        ddbs_stop_conn(conn)
-      }
-    }, add = TRUE)
-    expect_equal(
-      DBI::dbGetQuery(conn, "SELECT value FROM extension_check")$value,
-      1
-    )
-    ddbs_stop_conn(conn)
+    # 2. Reopen and verify
+    local({
+      conn_reopened <- ddbs_temp_conn(file = db_path, cleanup = FALSE)
+      expect_equal(
+        DBI::dbGetQuery(conn_reopened, "SELECT value FROM extension_check")$value,
+        1
+      )
+    })
   }
 
   expect_error(

--- a/tests/testthat/test-connection-management.R
+++ b/tests/testthat/test-connection-management.R
@@ -8,20 +8,18 @@ test_that("ddbs_create_conn accepts only supported DuckDB file extensions", {
     db_path <- tempfile(fileext = ext)
     on.exit(unlink(db_path), add = TRUE)
 
-    # 1. Create and write (using explicit cleanup = FALSE to keep file for step 2)
-    local({
-      conn <- ddbs_temp_conn(file = db_path, cleanup = FALSE)
-      DBI::dbExecute(conn, "CREATE TABLE extension_check AS SELECT 1 AS value")
-    })
+    # 1. Create and write using public API
+    conn <- ddbs_create_conn(dbdir = db_path)
+    DBI::dbExecute(conn, "CREATE TABLE extension_check AS SELECT 1 AS value")
+    ddbs_stop_conn(conn)
 
-    # 2. Reopen and verify
-    local({
-      conn_reopened <- ddbs_temp_conn(file = db_path, cleanup = FALSE)
-      expect_equal(
-        DBI::dbGetQuery(conn_reopened, "SELECT value FROM extension_check")$value,
-        1
-      )
-    })
+    # 2. Reopen and verify using public API
+    conn_reopened <- ddbs_create_conn(dbdir = db_path)
+    expect_equal(
+      DBI::dbGetQuery(conn_reopened, "SELECT value FROM extension_check")$value,
+      1
+    )
+    ddbs_stop_conn(conn_reopened)
   }
 
   expect_error(
@@ -100,4 +98,29 @@ test_that("ddbs_crs works on character tables without CRS column using view anal
   # Should find EPSG:4267
   expect_false(is.na(crs))
   expect_equal(crs$epsg, 4267)
+})
+
+test_that("ddbs_open_dataset does not leak connections on error with persistent files", {
+  db_path <- tempfile(fileext = ".duckdb")
+  on.exit(unlink(db_path), add = TRUE)
+  
+  # Create a dummy duckdb file with one table
+  local({
+    conn <- ddbs_create_conn(db_path)
+    DBI::dbExecute(conn, "CREATE TABLE my_table AS SELECT 1 AS id")
+    ddbs_stop_conn(conn)
+  })
+  
+  # Try to open a NON-EXISTENT layer. This triggers the error inside tryCatch
+  # after the connection is opened.
+  expect_error(
+    ddbs_open_dataset(db_path, layer = "non_existent_layer"),
+    "not present in DuckDB database"
+  )
+  
+  # If the connection leaked, the file might be locked. 
+  # Attempting to delete it should succeed if closed.
+  # (On Windows this is a strong check; on Unix it is less so but still good practice)
+  expect_true(unlink(db_path) == 0)
+  expect_false(file.exists(db_path))
 })

--- a/tests/testthat/test-crs-persistence.R
+++ b/tests/testthat/test-crs-persistence.R
@@ -54,11 +54,11 @@ test_that("ddbs_create_conn persists native CRS metadata in v1.5 storage", {
   )))
 })
 
-test_that("legacy storage writes and reads CRS column comments", {
+test_that("v1.0.0 storage (Legacy Compatibility) writes and reads CRS column comments", {
   db_path <- tempfile(fileext = ".duckdb")
   on.exit(unlink(db_path), add = TRUE)
 
-  conn <- ddbs_create_conn(db_path, storage_version = "legacy")
+  conn <- ddbs_create_conn(db_path, duckdb_storage_version = "v1.0.0")
   expect_equal(attr(conn, "duckspatial_storage_mode"), "legacy")
   on.exit(
     suppressWarnings(try(ddbs_stop_conn(conn), silent = TRUE)),
@@ -72,7 +72,7 @@ test_that("legacy storage writes and reads CRS column comments", {
   expect_equal(sf::st_crs(ddbs_crs("points", conn = conn))$epsg, 4326)
   ddbs_stop_conn(conn)
 
-  conn2 <- ddbs_create_conn(db_path, storage_version = "legacy")
+  conn2 <- ddbs_create_conn(db_path, duckdb_storage_version = "v1.0.0")
   expect_equal(attr(conn2, "duckspatial_storage_mode"), "legacy")
   on.exit(
     suppressWarnings(try(ddbs_stop_conn(conn2), silent = TRUE)),
@@ -108,7 +108,7 @@ test_that("ddbs_write_dataset writes native DuckDB database files", {
   expect_equal(sf::st_crs(ds)$epsg, 4326)
 })
 
-test_that("ddbs_write_dataset legacy DuckDB output writes CRS column comments", {
+test_that("ddbs_write_dataset v1.0.0 DuckDB output (Legacy Compatibility) writes CRS column comments", {
   db_path <- tempfile(fileext = ".duckdb")
   on.exit(unlink(db_path), add = TRUE)
 
@@ -117,12 +117,12 @@ test_that("ddbs_write_dataset legacy DuckDB output writes CRS column comments", 
       points_sf[1:3, ],
       db_path,
       layer = "points",
-      storage_version = "legacy",
+      duckdb_storage_version = "v1.0.0",
       quiet = TRUE
     )
   )
 
-  conn <- ddbs_create_conn(db_path, storage_version = "legacy")
+  conn <- ddbs_create_conn(db_path, duckdb_storage_version = "v1.0.0")
   expect_equal(attr(conn, "duckspatial_storage_mode"), "legacy")
   on.exit(
     suppressWarnings(try(ddbs_stop_conn(conn), silent = TRUE)),
@@ -184,7 +184,7 @@ test_that("custom proj4 CRS round-trips through native and comment metadata", {
   expect_true(duckspatial:::crs_equal(native_crs, sf::st_crs(custom_crs)))
   expect_false(is.na(duckspatial:::read_native_crs(native_conn2, "pts", "geom")))
 
-  compat_conn <- ddbs_create_conn(compat_db, storage_version = "legacy")
+  compat_conn <- ddbs_create_conn(compat_db, duckdb_storage_version = "v1.0.0")
   on.exit(
     suppressWarnings(try(ddbs_stop_conn(compat_conn), silent = TRUE)),
     add = TRUE
@@ -192,7 +192,7 @@ test_that("custom proj4 CRS round-trips through native and comment metadata", {
   ddbs_write_table(compat_conn, custom_points, "pts", quiet = TRUE)
   ddbs_stop_conn(compat_conn)
 
-  compat_conn2 <- ddbs_create_conn(compat_db, storage_version = "legacy")
+  compat_conn2 <- ddbs_create_conn(compat_db, duckdb_storage_version = "v1.0.0")
   on.exit(
     suppressWarnings(try(ddbs_stop_conn(compat_conn2), silent = TRUE)),
     add = TRUE

--- a/tests/testthat/test-crs-persistence.R
+++ b/tests/testthat/test-crs-persistence.R
@@ -1,0 +1,212 @@
+testthat::skip_on_cran()
+testthat::skip_if_not_installed("duckdb", minimum_version = "1.5.0")
+testthat::skip_if_not_installed("sf")
+
+test_that("duckdb geometry type preserves authority and custom CRS literals", {
+  conn <- ddbs_temp_conn()
+
+  expect_equal(
+    duckspatial:::duckdb_geometry_type(conn, "EPSG:4326"),
+    "GEOMETRY('EPSG:4326')"
+  )
+  expect_equal(duckspatial:::duckdb_geometry_type(conn, NA), "GEOMETRY")
+
+  custom <- "+proj=lcc +lat_0=49 +lon_0=-95 +lat_1=49 +lat_2=77 +datum=NAD83"
+  literal <- duckspatial:::crs_to_duckdb_literal(custom)
+  expect_equal(literal$kind, "wkt")
+  expect_match(
+    duckspatial:::duckdb_geometry_type(conn, custom),
+    "^GEOMETRY\\('PROJCRS",
+    perl = TRUE
+  )
+})
+
+test_that("ddbs_create_conn persists native CRS metadata in v1.5 storage", {
+  db_path <- tempfile(fileext = ".duckdb")
+  on.exit(unlink(db_path), add = TRUE)
+
+  conn <- ddbs_create_conn(db_path)
+  expect_equal(attr(conn, "duckspatial_storage_mode"), "v1.5.0")
+  expect_equal(attr(conn, "duckspatial_storage"), "v1.5.0+")
+  on.exit(
+    suppressWarnings(try(ddbs_stop_conn(conn), silent = TRUE)),
+    add = TRUE
+  )
+  ddbs_write_table(conn, points_sf[1:3, ], "points", quiet = TRUE)
+  ddbs_stop_conn(conn)
+
+  conn2 <- ddbs_create_conn(db_path)
+  expect_equal(attr(conn2, "duckspatial_storage_mode"), "v1.5.0")
+  expect_equal(attr(conn2, "duckspatial_storage"), "v1.5.0+")
+  on.exit(
+    suppressWarnings(try(ddbs_stop_conn(conn2), silent = TRUE)),
+    add = TRUE
+  )
+  ds <- as_duckspatial_df("points", conn = conn2)
+  geom_col <- attr(ds, "sf_column")
+
+  expect_equal(sf::st_crs(ds)$epsg, 4326)
+  expect_false(is.na(duckspatial:::read_native_crs(conn2, "points", geom_col)))
+  expect_true(is.na(duckspatial:::get_column_comment(
+    conn2,
+    "points",
+    geom_col
+  )))
+})
+
+test_that("legacy storage writes and reads CRS column comments", {
+  db_path <- tempfile(fileext = ".duckdb")
+  on.exit(unlink(db_path), add = TRUE)
+
+  conn <- ddbs_create_conn(db_path, storage_version = "legacy")
+  expect_equal(attr(conn, "duckspatial_storage_mode"), "legacy")
+  on.exit(
+    suppressWarnings(try(ddbs_stop_conn(conn), silent = TRUE)),
+    add = TRUE
+  )
+  ddbs_write_table(conn, points_sf[1:3, ], "points", quiet = TRUE)
+  geom_col <- get_geom_name(conn, "points")
+
+  comment <- duckspatial:::get_column_comment(conn, "points", geom_col)
+  expect_match(comment, "\"duckspatial\"", fixed = TRUE)
+  expect_equal(sf::st_crs(ddbs_crs("points", conn = conn))$epsg, 4326)
+  ddbs_stop_conn(conn)
+
+  conn2 <- ddbs_create_conn(db_path, storage_version = "legacy")
+  expect_equal(attr(conn2, "duckspatial_storage_mode"), "legacy")
+  on.exit(
+    suppressWarnings(try(ddbs_stop_conn(conn2), silent = TRUE)),
+    add = TRUE
+  )
+  expect_equal(sf::st_crs(ddbs_crs("points", conn = conn2))$epsg, 4326)
+})
+
+test_that("ddbs_write_dataset writes native DuckDB database files", {
+  db_path <- tempfile(fileext = ".duckdb")
+  on.exit(unlink(db_path), add = TRUE)
+
+  expect_no_error(
+    ddbs_write_dataset(
+      points_sf[1:3, ],
+      db_path,
+      layer = "points",
+      quiet = TRUE
+    )
+  )
+
+  conn <- ddbs_create_conn(db_path)
+  on.exit(
+    suppressWarnings(try(ddbs_stop_conn(conn), silent = TRUE)),
+    add = TRUE
+  )
+  ds <- ddbs_open_dataset(db_path, layer = "points")
+  on.exit(
+    suppressWarnings(try(
+      ddbs_stop_conn(attr(ds, "source_conn")),
+      silent = TRUE
+    )),
+    add = TRUE
+  )
+
+  expect_s3_class(ds, "duckspatial_df")
+  expect_equal(dplyr::count(ds) |> dplyr::pull(n), 3)
+  expect_equal(sf::st_crs(ds)$epsg, 4326)
+})
+
+test_that("ddbs_write_dataset legacy DuckDB output writes CRS column comments", {
+  db_path <- tempfile(fileext = ".duckdb")
+  on.exit(unlink(db_path), add = TRUE)
+
+  expect_no_error(
+    ddbs_write_dataset(
+      points_sf[1:3, ],
+      db_path,
+      layer = "points",
+      storage_version = "legacy",
+      quiet = TRUE
+    )
+  )
+
+  conn <- ddbs_create_conn(db_path, storage_version = "legacy")
+  expect_equal(attr(conn, "duckspatial_storage_mode"), "legacy")
+  on.exit(
+    suppressWarnings(try(ddbs_stop_conn(conn), silent = TRUE)),
+    add = TRUE
+  )
+
+  geom_col <- get_geom_name(conn, "points")
+  comment <- duckspatial:::get_column_comment(conn, "points", geom_col)
+
+  expect_match(comment, "\"duckspatial\"", fixed = TRUE)
+  expect_equal(sf::st_crs(ddbs_crs("points", conn = conn))$epsg, 4326)
+
+  expect_no_warning({
+    ds <- ddbs_open_dataset(db_path, layer = "points")
+  })
+  on.exit(
+    suppressWarnings(try(
+      ddbs_stop_conn(attr(ds, "source_conn")),
+      silent = TRUE
+    )),
+    add = TRUE
+  )
+  expect_equal(sf::st_crs(ds)$epsg, 4326)
+})
+
+test_that("custom proj4 CRS round-trips through native and comment metadata", {
+  custom_crs <- paste(
+    "+proj=lcc +lat_0=49 +lon_0=-95 +lat_1=49 +lat_2=77",
+    "+datum=NAD83 +units=m +no_defs"
+  )
+  custom_points <- sf::st_sf(
+    id = 1:2,
+    geom = sf::st_sfc(
+      sf::st_point(c(0, 0)),
+      sf::st_point(c(1000, 1000)),
+      crs = custom_crs
+    )
+  )
+
+  native_db <- tempfile(fileext = ".duckdb")
+  compat_db <- tempfile(fileext = ".duckdb")
+  on.exit(unlink(c(native_db, compat_db)), add = TRUE)
+
+  native_conn <- ddbs_create_conn(native_db)
+  on.exit(
+    suppressWarnings(try(ddbs_stop_conn(native_conn), silent = TRUE)),
+    add = TRUE
+  )
+  ddbs_write_table(native_conn, custom_points, "pts", quiet = TRUE)
+  ddbs_stop_conn(native_conn)
+
+  native_conn2 <- ddbs_create_conn(native_db)
+  on.exit(
+    suppressWarnings(try(ddbs_stop_conn(native_conn2), silent = TRUE)),
+    add = TRUE
+  )
+  native_crs <- ddbs_crs("pts", conn = native_conn2)
+  expect_true(duckspatial:::crs_equal(native_crs, sf::st_crs(custom_crs)))
+  expect_false(is.na(duckspatial:::read_native_crs(native_conn2, "pts", "geom")))
+
+  compat_conn <- ddbs_create_conn(compat_db, storage_version = "legacy")
+  on.exit(
+    suppressWarnings(try(ddbs_stop_conn(compat_conn), silent = TRUE)),
+    add = TRUE
+  )
+  ddbs_write_table(compat_conn, custom_points, "pts", quiet = TRUE)
+  ddbs_stop_conn(compat_conn)
+
+  compat_conn2 <- ddbs_create_conn(compat_db, storage_version = "legacy")
+  on.exit(
+    suppressWarnings(try(ddbs_stop_conn(compat_conn2), silent = TRUE)),
+    add = TRUE
+  )
+  compat_crs <- ddbs_crs("pts", conn = compat_conn2)
+  expect_true(duckspatial:::crs_equal(compat_crs, sf::st_crs(custom_crs)))
+  expect_true(is.na(duckspatial:::read_native_crs(compat_conn2, "pts", "geom")))
+  expect_match(
+    duckspatial:::get_column_comment(compat_conn2, "pts", "geom"),
+    "\"wkt2_2019\"",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-crs-persistence.R
+++ b/tests/testthat/test-crs-persistence.R
@@ -1,5 +1,5 @@
 testthat::skip_on_cran()
-testthat::skip_if_not_installed("duckdb", minimum_version = "1.5.0")
+testthat::skip_if_not_installed("duckdb", minimum_version = "1.5.1")
 testthat::skip_if_not_installed("sf")
 
 test_that("duckdb geometry type preserves authority and custom CRS literals", {

--- a/tests/testthat/test-crs-persistence.R
+++ b/tests/testthat/test-crs-persistence.R
@@ -94,11 +94,6 @@ test_that("ddbs_write_dataset writes native DuckDB database files", {
     )
   )
 
-  conn <- ddbs_create_conn(db_path)
-  on.exit(
-    suppressWarnings(try(ddbs_stop_conn(conn), silent = TRUE)),
-    add = TRUE
-  )
   ds <- ddbs_open_dataset(db_path, layer = "points")
   on.exit(
     suppressWarnings(try(
@@ -139,6 +134,7 @@ test_that("ddbs_write_dataset legacy DuckDB output writes CRS column comments", 
 
   expect_match(comment, "\"duckspatial\"", fixed = TRUE)
   expect_equal(sf::st_crs(ddbs_crs("points", conn = conn))$epsg, 4326)
+  ddbs_stop_conn(conn)
 
   expect_no_warning({
     ds <- ddbs_open_dataset(db_path, layer = "points")

--- a/tests/testthat/test-ddbs_open_dataset.R
+++ b/tests/testthat/test-ddbs_open_dataset.R
@@ -363,12 +363,15 @@ test_that("ddbs_open_dataset validates DuckDB files properly", {
     "not a valid DuckDB database"
   )
 
+  # Use a unique file for the valid DuckDB test to avoid any interference
+  # We use the established ddbs_temp_conn helper for clean connection management
   tmp_good_duck <- tempfile(fileext = ".duckdb")
   on.exit(unlink(tmp_good_duck), add = TRUE)
 
-  conn <- ddbs_create_conn(tmp_good_duck)
-  ddbs_write_table(conn, countries_sf, "countries")
-  ddbs_stop_conn(conn)
+  local({
+    conn <- ddbs_temp_conn(file = tmp_good_duck, cleanup = FALSE)
+    ddbs_write_table(conn, countries_sf, "countries", quiet = TRUE)
+  })
 
   expect_error(
     ddbs_open_dataset(tmp_good_duck),
@@ -381,25 +384,25 @@ test_that("ddbs_open_dataset validates DuckDB files properly", {
   )
 
   ds <- ddbs_open_dataset(tmp_good_duck, layer = "countries", crs = 4326)
-  on.exit(ddbs_stop_conn(attr(ds, "source_conn")), add = TRUE)
   expect_s3_class(ds, "duckspatial_df")
   expect_equal(as.character(dbplyr::remote_name(ds)), "countries")
   expect_equal(nrow(dplyr::collect(ds)), nrow(countries_sf))
 })
 
 test_that("ddbs_open_dataset opens supported DuckDB file extensions", {
+  # Helper to create a fresh DB file for each extension to avoid lock issues
   create_duckdb_test_file <- function(ext) {
     db_path <- tempfile(fileext = ext)
-    conn <- ddbs_create_conn(db_path)
-    on.exit(ddbs_stop_conn(conn), add = TRUE)
-    ddbs_write_table(conn, countries_sf, "countries")
+    local({
+      conn <- ddbs_temp_conn(file = db_path, cleanup = FALSE)
+      ddbs_write_table(conn, countries_sf, "countries", quiet = TRUE)
+    })
     db_path
   }
 
   expect_duckdb_open <- function(db_path) {
     on.exit(unlink(db_path), add = TRUE)
     ds <- ddbs_open_dataset(db_path, layer = "countries", crs = 4326)
-    on.exit(ddbs_stop_conn(attr(ds, "source_conn")), add = TRUE)
 
     expect_s3_class(ds, "duckspatial_df")
     expect_equal(as.character(dbplyr::remote_name(ds)), "countries")

--- a/tests/testthat/test-ddbs_open_dataset.R
+++ b/tests/testthat/test-ddbs_open_dataset.R
@@ -336,3 +336,108 @@ test_that("ddbs_open_dataset fails gracefully on non-compliant GeoArrow structs"
   
   expect_error(ddbs_open_dataset(tmp_bad), "uses a native Arrow/GeoArrow struct encoding")
 })
+
+# =============================================================================
+# DuckDB Native Format Support
+# =============================================================================
+
+test_that("ddbs_open_dataset validates DuckDB files properly", {
+  expect_error(
+    ddbs_open_dataset("/nonexistent_path.duckdb"),
+    "does not exist"
+  )
+
+  tmp_empty_duck <- tempfile(fileext = ".duckdb")
+  on.exit(unlink(tmp_empty_duck), add = TRUE)
+  file.create(tmp_empty_duck)
+  expect_error(
+    ddbs_open_dataset(tmp_empty_duck),
+    "not a valid DuckDB database"
+  )
+
+  tmp_bad_duck <- tempfile(fileext = ".duckdb")
+  on.exit(unlink(tmp_bad_duck), add = TRUE)
+  writeLines("this is just text", tmp_bad_duck)
+  expect_error(
+    ddbs_open_dataset(tmp_bad_duck),
+    "not a valid DuckDB database"
+  )
+
+  tmp_good_duck <- tempfile(fileext = ".duckdb")
+  on.exit(unlink(tmp_good_duck), add = TRUE)
+
+  conn <- ddbs_create_conn(tmp_good_duck)
+  ddbs_write_table(conn, countries_sf, "countries")
+  ddbs_stop_conn(conn)
+
+  expect_error(
+    ddbs_open_dataset(tmp_good_duck),
+    "layer"
+  )
+
+  expect_error(
+    ddbs_open_dataset(tmp_good_duck, layer = "missing_table"),
+    "not present"
+  )
+
+  ds <- ddbs_open_dataset(tmp_good_duck, layer = "countries", crs = 4326)
+  on.exit(ddbs_stop_conn(attr(ds, "source_conn")), add = TRUE)
+  expect_s3_class(ds, "duckspatial_df")
+  expect_equal(as.character(dbplyr::remote_name(ds)), "countries")
+  expect_equal(nrow(dplyr::collect(ds)), nrow(countries_sf))
+})
+
+test_that("ddbs_open_dataset opens supported DuckDB file extensions", {
+  create_duckdb_test_file <- function(ext) {
+    db_path <- tempfile(fileext = ext)
+    conn <- ddbs_create_conn(db_path)
+    on.exit(ddbs_stop_conn(conn), add = TRUE)
+    ddbs_write_table(conn, countries_sf, "countries")
+    db_path
+  }
+
+  expect_duckdb_open <- function(db_path) {
+    on.exit(unlink(db_path), add = TRUE)
+    ds <- ddbs_open_dataset(db_path, layer = "countries", crs = 4326)
+    on.exit(ddbs_stop_conn(attr(ds, "source_conn")), add = TRUE)
+
+    expect_s3_class(ds, "duckspatial_df")
+    expect_equal(as.character(dbplyr::remote_name(ds)), "countries")
+    expect_equal(nrow(dplyr::collect(ds)), nrow(countries_sf))
+  }
+
+  for (ext in c(".duckdb", ".db", ".ddb")) {
+    expect_duckdb_open(create_duckdb_test_file(ext))
+  }
+})
+
+test_that("ddbs_open_dataset does not open DuckDB files with unsupported extensions natively", {
+  tmp_txt <- tempfile(fileext = ".txt")
+  conn <- duckdb::dbConnect(duckdb::duckdb(), dbdir = tmp_txt)
+  on.exit(unlink(tmp_txt), add = TRUE)
+  on.exit({
+    if (DBI::dbIsValid(conn)) {
+      DBI::dbDisconnect(conn, shutdown = TRUE)
+    }
+  }, add = TRUE)
+  DBI::dbExecute(conn, "CREATE TABLE countries AS SELECT 1 AS value")
+  DBI::dbDisconnect(conn, shutdown = TRUE)
+
+  expect_error(
+    ddbs_open_dataset(tmp_txt, layer = "countries"),
+    regexp = "Unable to open file",
+    ignore.case = TRUE
+  )
+})
+
+test_that("ddbs_open_dataset lets non-DuckDB .db files fall through to ST_Read", {
+  tmp_db <- tempfile(fileext = ".db")
+  on.exit(unlink(tmp_db), add = TRUE)
+  writeLines("not a duckdb database", tmp_db)
+
+  expect_error(
+    ddbs_open_dataset(tmp_db),
+    regexp = "Unable to open file",
+    ignore.case = TRUE
+  )
+})

--- a/tests/testthat/test-ddbs_open_dataset.R
+++ b/tests/testthat/test-ddbs_open_dataset.R
@@ -416,15 +416,12 @@ test_that("ddbs_open_dataset opens supported DuckDB file extensions", {
 
 test_that("ddbs_open_dataset does not open DuckDB files with unsupported extensions natively", {
   tmp_txt <- tempfile(fileext = ".txt")
-  conn <- duckdb::dbConnect(duckdb::duckdb(), dbdir = tmp_txt)
   on.exit(unlink(tmp_txt), add = TRUE)
-  on.exit({
-    if (DBI::dbIsValid(conn)) {
-      DBI::dbDisconnect(conn, shutdown = TRUE)
-    }
-  }, add = TRUE)
-  DBI::dbExecute(conn, "CREATE TABLE countries AS SELECT 1 AS value")
-  DBI::dbDisconnect(conn, shutdown = TRUE)
+
+  local({
+    conn <- ddbs_temp_conn(file = tmp_txt, cleanup = FALSE)
+    DBI::dbExecute(conn, "CREATE TABLE countries AS SELECT 1 AS value")
+  })
 
   expect_error(
     ddbs_open_dataset(tmp_txt, layer = "countries"),

--- a/tests/testthat/test-duckspatial_df.R
+++ b/tests/testthat/test-duckspatial_df.R
@@ -21,7 +21,7 @@ test_that("new_duckspatial_df creates valid duckspatial_df objects", {
   expect_s3_class(result, "duckspatial_df")
   expect_s3_class(result, "tbl_lazy")
   expect_equal(attr(result, "sf_column"), "geometry")
-  expect_equal(attr(result, "crs"), sf::st_crs(nc_sf))
+  expect_true(duckspatial:::crs_equal(attr(result, "crs"), sf::st_crs(nc_sf)))
   expect_equal(attr(result, "source_table"), "nc_test")
 })
 
@@ -56,7 +56,7 @@ test_that("as_duckspatial_df.sf works correctly", {
   
   expect_s3_class(result, "duckspatial_df")
   expect_s3_class(result, "tbl_lazy")
-  expect_equal(attr(result, "crs"), sf::st_crs(nc_sf))
+  expect_true(duckspatial:::crs_equal(attr(result, "crs"), sf::st_crs(nc_sf)))
   expect_equal(attr(result, "sf_column"), attr(nc_sf, "sf_column"))
 })
 
@@ -65,10 +65,11 @@ test_that("as_duckspatial_df.tbl_duckdb_connection works correctly", {
   ddbs_write_table(conn, nc_sf, "nc_test", quiet = TRUE)
   
   lazy_tbl <- dplyr::tbl(conn, "nc_test")
-  result <- as_duckspatial_df(lazy_tbl, crs = sf::st_crs(nc_sf))
+  # Auto-detection should work now!
+  result <- as_duckspatial_df(lazy_tbl)
   
   expect_s3_class(result, "duckspatial_df")
-  expect_equal(attr(result, "crs"), sf::st_crs(nc_sf))
+  expect_true(duckspatial:::crs_equal(attr(result, "crs"), sf::st_crs(nc_sf)))
 })
 
 test_that("as_duckspatial_df.tbl_lazy works correctly", {
@@ -79,7 +80,7 @@ test_that("as_duckspatial_df.tbl_lazy works correctly", {
   result <- as_duckspatial_df(lazy_tbl, crs = sf::st_crs(nc_sf))  
   
   expect_s3_class(result, "duckspatial_df")
-  expect_equal(attr(result, "crs"), sf::st_crs(nc_sf))
+  expect_true(duckspatial:::crs_equal(attr(result, "crs"), sf::st_crs(nc_sf)))
 })
 
 test_that("as_duckspatial_df.character works correctly", {

--- a/tests/testthat/test-tmp_conn.R
+++ b/tests/testthat/test-tmp_conn.R
@@ -56,7 +56,7 @@ test_that("ddbs_temp_conn: custom file path", {
 })
 
 test_that("ddbs_temp_conn: custom path with cleanup = FALSE", {
-  custom_path <- tempfile(fileext = ".persistent")
+  custom_path <- tempfile(fileext = ".duckdb")
   
   test_no_cleanup <- function(path) {
     c <- ddbs_temp_conn(file = path, cleanup = FALSE)
@@ -67,11 +67,12 @@ test_that("ddbs_temp_conn: custom path with cleanup = FALSE", {
   
   # File should STILL exist
   expect_true(file.exists(custom_path))
+  expect_false(file.exists(paste0(custom_path, ".wal")))
   
   # Verify we can connect to it
-  c2 <- DBI::dbConnect(duckdb::duckdb(), dbdir = custom_path)
+  c2 <- ddbs_create_conn(custom_path)
   expect_true("t" %in% DBI::dbListTables(c2))
-  DBI::dbDisconnect(c2, shutdown = TRUE)
+  ddbs_stop_conn(c2)
   
   # Clean up manually
   unlink(custom_path)

--- a/vignettes/duckspatial.qmd
+++ b/vignettes/duckspatial.qmd
@@ -268,14 +268,16 @@ You can easily reopen a saved DuckDB database and lazily "register" the spatial 
 
 **A Note on CRS Persistence:** By default, `duckspatial` ensures that CRS metadata is preserved when saving tables to persistent DuckDB files. It achieves this using two complementary strategies:
 
-1. **Native Persistence** (`storage_version = "v1.5.0"`): When using DuckDB 1.5.0+ (the default mode in both `ddbs_create_conn()` and `ddbs_write_dataset()`), CRS information is stored directly within the database catalog.
-2. **Metadata Fallback** (`storage_version = "legacy"`): For older DuckDB versions or legacy storage modes, `duckspatial` embeds the CRS as a specialized JSON comment on the geometry column.
+1. **Native Spatial Storage** (`duckdb_storage_version = "v1.5.0"`): When using DuckDB 1.5.0+ (the default mode in both `ddbs_create_conn()` and `ddbs_write_dataset()`), CRS information is stored directly within the database catalog.
+2. **Legacy Compatibility** (`duckdb_storage_version = "v1.0.0"`): For older DuckDB versions or legacy storage modes, `duckspatial` embeds the CRS as a specialized JSON comment on the geometry column.
+
+For more information on DuckDB storage versions and compatibility guarantees, see the official [DuckDB Storage documentation](https://duckdb.org/docs/internals/storage).
 
 ::: {.callout-note}
 ### Technical Note on Interoperability
-The **Metadata Fallback** strategy is a `duckspatial`-specific convention. Because DuckDB does not natively support CRS metadata in older storage versions, we "hijack" the column comment field to store this information. 
+The **Legacy Compatibility** strategy is a `duckspatial`-specific convention. Because DuckDB does not natively support CRS metadata in older storage versions, we "hijack" the column comment field to store this information. 
 
-While this ensures consistent behavior within `duckspatial`, **other spatial software (like QGIS, GDAL, or other DuckDB clients) will not recognize this metadata.** If you need to share your DuckDB files with other tools while preserving CRS, we strongly recommend using the **Native Persistence** (default) or exporting to **GeoParquet**.
+While this ensures consistent behavior within `duckspatial`, **other spatial software (like QGIS, GDAL, or other DuckDB clients) will not recognize this metadata.** If you need to share your DuckDB files with other tools while preserving CRS, we strongly recommend using the **Native Spatial Storage** (default) or exporting to **GeoParquet**.
 :::
 
 This means that in most cases, you **do not** need to provide a `crs` argument when reopening a table:

--- a/vignettes/duckspatial.qmd
+++ b/vignettes/duckspatial.qmd
@@ -261,3 +261,20 @@ ddbs_write_table(conn, world_ddbs, name = "world")
 ## close — "my_database.duckdb" will persist on disk
 ddbs_stop_conn(conn)
 ```
+
+### Reopening saved tables
+
+You can easily reopen a saved DuckDB database and lazily "register" the spatial tables using either `ddbs_open_dataset()` directly on the file, or `as_duckspatial_df()` if you are manually managing connections.
+
+**Important Note on CRS:** Due to a known upstream limitation in DuckDB (as of v1.5), CRS metadata attached to `GEOMETRY` columns is currently dropped when the database connection is closed. Therefore, you must manually provide the `crs` argument when reopening tables from a persistent `.duckdb` file:
+
+```r
+# Option 1: Direct file reading (automatically manages connection)
+reopened_world <- ddbs_open_dataset("my_database.duckdb", layer = "world", crs = 4326)
+
+# Option 2: Manual connection management
+conn <- ddbs_create_conn("my_database.duckdb")
+reopened_world <- as_duckspatial_df("world", conn = conn, crs = 4326)
+```
+
+**Recommendation:** Because of this limitation, if your workflow relies heavily on preserving precise CRS metadata across sessions without manual intervention, **saving your data to GeoParquet files (`.parquet`) via `ddbs_write_dataset()` is highly recommended** over saving tables directly into `.duckdb` files. GeoParquet natively and durably embeds the CRS.

--- a/vignettes/duckspatial.qmd
+++ b/vignettes/duckspatial.qmd
@@ -266,15 +266,27 @@ ddbs_stop_conn(conn)
 
 You can easily reopen a saved DuckDB database and lazily "register" the spatial tables using either `ddbs_open_dataset()` directly on the file, or `as_duckspatial_df()` if you are manually managing connections.
 
-**Important Note on CRS:** Due to a known upstream limitation in DuckDB (as of v1.5), CRS metadata attached to `GEOMETRY` columns is currently dropped when the database connection is closed. Therefore, you must manually provide the `crs` argument when reopening tables from a persistent `.duckdb` file:
+**A Note on CRS Persistence:** By default, `duckspatial` ensures that CRS metadata is preserved when saving tables to persistent DuckDB files. It achieves this using two complementary strategies:
+
+1. **Native Persistence** (`storage_version = "v1.5.0"`): When using DuckDB 1.5.0+ (the default mode in both `ddbs_create_conn()` and `ddbs_write_dataset()`), CRS information is stored directly within the database catalog.
+2. **Metadata Fallback** (`storage_version = "legacy"`): For older DuckDB versions or legacy storage modes, `duckspatial` embeds the CRS as a specialized JSON comment on the geometry column.
+
+::: {.callout-note}
+### Technical Note on Interoperability
+The **Metadata Fallback** strategy is a `duckspatial`-specific convention. Because DuckDB does not natively support CRS metadata in older storage versions, we "hijack" the column comment field to store this information. 
+
+While this ensures consistent behavior within `duckspatial`, **other spatial software (like QGIS, GDAL, or other DuckDB clients) will not recognize this metadata.** If you need to share your DuckDB files with other tools while preserving CRS, we strongly recommend using the **Native Persistence** (default) or exporting to **GeoParquet**.
+:::
+
+This means that in most cases, you **do not** need to provide a `crs` argument when reopening a table:
 
 ```r
-# Option 1: Direct file reading (automatically manages connection)
-reopened_world <- ddbs_open_dataset("my_database.duckdb", layer = "world", crs = 4326)
-
-# Option 2: Manual connection management
-conn <- ddbs_create_conn("my_database.duckdb")
-reopened_world <- as_duckspatial_df("world", conn = conn, crs = 4326)
+# CRS is automatically detected in most cases
+reopened_world <- ddbs_open_dataset("my_database.duckdb", layer = "world")
 ```
 
-**Recommendation:** Because of this limitation, if your workflow relies heavily on preserving precise CRS metadata across sessions without manual intervention, **saving your data to GeoParquet files (`.parquet`) via `ddbs_write_dataset()` is highly recommended** over saving tables directly into `.duckdb` files. GeoParquet natively and durably embeds the CRS.
+Manual CRS input is typically only required if:
+* The original data lacked CRS information entirely.
+* You are reading a DuckDB file created by another tool that does not follow these persistence conventions.
+
+**Recommendation:** While DuckDB storage is now robust for spatial metadata, **saving your data to GeoParquet files (`.parquet`) via `ddbs_write_dataset()`** remains an excellent choice for interoperability, as GeoParquet is a standardized format designed specifically for durable spatial data storage.

--- a/vignettes/duckspatial.qmd
+++ b/vignettes/duckspatial.qmd
@@ -162,7 +162,7 @@ So far we have been using the default, temporary DuckDB connection that {duckspa
 There are two connection modes:
 
 -   **Non-persistent (in-memory):** data exists only for the duration of the R session or until it is closed. As of v1.0.0, this mode is kept for backward compatibility, but working with `duckspatial_df` objects directly achieves the same goals with less boilerplate.
--   **Persistent:** data is written to a `.duckdb` or `.db` file on disk and survives after the session ends.
+-   **Persistent:** data is written to a DuckDB database file on disk and survives after the session ends. {duckspatial} accepts `.duckdb`, `.db`, and `.ddb` paths for persistent DuckDB databases.
 
 ## Creating a connection
 


### PR DESCRIPTION
Fixes this:

```r
library(duckspatial)
library(dplyr)
library(sf) 
 
# 1. Open an in-memory connection 
conn <- ddbs_create_conn()

 # 2. Read the built-in NC shapefile that comes with the 'sf' package
nc <- st_read(system.file("shape/nc.shp", package = "sf"), quiet = TRUE)
 
# 3. Write it to DuckDB 
ddbs_write_table(conn, nc, "world") 
 
cat("\n--- Testing Way 1: Character input ---\n") 
# This works perfectly. It finds the CRS because it uses ST_CRS() 
ds1 <- as_duckspatial_df("world", conn = conn)
print(attr(ds1, "crs")) 

cat("\n--- Testing Way 2: tbl input (Currently broken) ---\n")
# This throws the warning! It never checks ST_CRS() 
world_tbl <- tbl(conn, "world") 
ds2 <- as_duckspatial_df(world_tbl) 
print(attr(ds2, "crs")) 

# 4. Clean up 
ddbs_stop_conn(conn)
```